### PR TITLE
Add tmux 1.8 installation instructions for Ubuntu 12.04/12.10/13.04.

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -7,7 +7,7 @@ Quickstart
 Installation
 ------------
 
-Assure you have at least tmux **>= 1.8** and python **>= 2.6**.
+Assure you have at least tmux **>= 1.8** and python **>= 2.6**. For Ubuntu 12.04/12.10/13.04 users, you can download the tmux 1.8 package for Ubuntu 13.10 from `https://launchpad.net/ubuntu/+source/tmux <https://launchpad.net/ubuntu/+source/tmux>`_ and install it using dpkg.
 
 .. code-block:: bash
 


### PR DESCRIPTION
IMO this is the easiest way to get tmuxp working on Ubuntu 12.04 LTS.
