### PR TITLE
Command is executed in the wrong window!

### DIFF
--- a/tmuxp/pane.py
+++ b/tmuxp/pane.py
@@ -67,7 +67,7 @@ class Pane(util.TmuxMappingObject, util.TmuxRelationalObject):
         :rtype: :class:`Server.tmux`
 
         """
-        if not len([arg for arg in args if '-t' in arg]):
+        if not any(arg.startswith('-t') for arg in args):
             args = ('-t', self.get('pane_id')) + args
 
         return self.server.tmux(cmd, *args, **kwargs)

--- a/tmuxp/window.py
+++ b/tmuxp/window.py
@@ -76,7 +76,7 @@ class Window(util.TmuxMappingObject, util.TmuxRelationalObject):
         :rtype: :class:`Server.tmux`
 
         """
-        if not len([arg for arg in args if '-t' in str(arg)]):
+        if not any(arg.startswith('-t') for arg in args):
             args = ('-t', self.get('window_id')) + args
 
         return self.server.tmux(cmd, *args, **kwargs)


### PR DESCRIPTION
I have this config (the echoes are just to avoid actually starting stuff while testing things).

After loading it, almost everything is fine except the `ssh indico-lb-test` command. It's _entered_ (not executed, i.e. no ENTER after the command) in the first pane of window 4 (actually in whatever pane is focused in that window, when removing the `focus` entry it's started in another pane of that window).

```
session_name: main
windows:
  #1 - root
  -
    window_name: root
    panes:
      -
        shell_command:
          - sudo su -
          - tmux a || tmux
  #2 - indico
  - 
    window_name: indico
    layout: "98b6,317x91,0,0[317x8,0,0,1,317x82,0,9,2]"
    start_directory: ~/dev/indico/src
    focus: true
    panes:
      - echo tail -f ../data/log/indico.log
      -
        focus: true
        shell_command:
  #3 - dev-a
  - 
    window_name: dev-a
    start_directory: ~/dev/indico/src
    panes:
      - echo ssh indicodev-adrian
  #4 - puppet
  -
    window_name: puppet
    layout: tiled
    start_directory:  ~/dev/it-puppet-hostgroup-indico
    panes:
      -
        focus: true
        shell_command:
      -
        start_directory: ~/dev/it-puppet-module-indico_linux_goodies
        shell_command:
      -
        start_directory: ~/dev/it-puppet-hostgroup-jabber
        shell_command:
      -
        start_directory: ~/dev/it-puppet-hostgroup-indic8r
        shell_command:
  #5 - lb-test
  - 
    window_name: lb-test
    panes:
      - echo ssh indico-lb-test
  #6 - cernres
  - 
    window_name: cernres
    start_directory: ~/dev/indico-cern-resources
    panes:
      -
  #7 - aiadm
  - 
    window_name: aiadm
    panes:
      - echo ssh aiadm
```
