### PR TITLE
don't require shell_command

### DIFF
--- a/examples/blank-panes.json
+++ b/examples/blank-panes.json
@@ -35,6 +35,17 @@
         }
       ], 
       "window_name": "Empty string (return)"
+    },
+    {
+      "panes": [
+        {
+          "focus": true
+        },
+        {
+          "start_directory": "/tmp"
+        }
+      ],
+      "window_name": "Blank with options"
     }
   ], 
   "session_name": "Blank pane test"

--- a/examples/blank-panes.yaml
+++ b/examples/blank-panes.yaml
@@ -20,3 +20,8 @@ windows:
     - shell_command: ''
     - shell_command:
       - ''
+  # a pane can have other options but still be blank
+  - window_name: Blank with options
+    panes:
+    - focus: true
+    - start_directory: /tmp

--- a/tmuxp/config.py
+++ b/tmuxp/config.py
@@ -209,7 +209,6 @@ def expand(sconf, cwd=None):
                 }
 
             assert isinstance(p, dict)
-            assert 'shell_command' in p
             if 'shell_command' in p:
                 cmd = p['shell_command']
 
@@ -224,6 +223,8 @@ def expand(sconf, cwd=None):
                         cmd = []
 
                 p['shell_command'] = cmd
+            else:
+                p['shell_command'] = []
 
             pconf.update(p)
         sconf['panes'] = [expand(pane) for pane in sconf['panes']]

--- a/tmuxp/testsuite/config.py
+++ b/tmuxp/testsuite/config.py
@@ -947,6 +947,19 @@ class ConfigBlankPanes(TestCase):
                         ],
                     }
                 ]
+            },
+            {
+                'window_name': 'Blank with options',
+                'panes': [
+                    {
+                        'shell_command': [],
+                        'focus': True,
+                    },
+                    {
+                        'shell_command': [],
+                        'start_directory': '/tmp',
+                    }
+                ]
             }
         ]
     }

--- a/tmuxp/testsuite/workspacebuilder.py
+++ b/tmuxp/testsuite/workspacebuilder.py
@@ -358,6 +358,9 @@ class BlankPaneTest(TmuxTestCase):
         )
         self.assertEqual(len(window3._panes), 3)
 
+        window4 = self.session.findWhere({'window_name': 'Blank with options'})
+        self.assertEqual(len(window4._panes), 2)
+
 
 class StartDirectoryTest(TmuxTestCase):
     yaml_config = """


### PR DESCRIPTION
Right now this fails:

```
    panes:
      - focus: true
```

while this works:

```
    panes:
      - focus: true
        shell_command:
```

or this:

```
    panes:
      -
```

It would be nice if `shell_command` defaulted to empty even if other keys were present for the pane.
