### PR TITLE
Use session's start_directory in session creation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@ Here you can find the recent changes to tmuxp
 
 current
 -------
+- :issue:`197` The `start_directory` toplevel config now sets the session's
+  `start-directory`. This affects the working directory of newly created
+  windows in that session.
 - :issue:`623` Move docs from RTD to self-serve site
 - :issue:`623` Modernize Makefiles
 - :issue:`623` New development docs

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -138,7 +138,8 @@ class WorkspaceBuilder(object):
                 )
             else:
                 session = self.server.new_session(
-                    session_name=self.sconf['session_name']
+                    session_name=self.sconf['session_name'],
+                    start_directory=self.sconf['start_directory'],
                 )
 
             assert self.sconf['session_name'] == session.name

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -15,6 +15,7 @@ from libtmux.pane import Pane
 from libtmux.server import Server
 from libtmux.session import Session
 from libtmux.window import Window
+from libtmux.common import has_version
 
 from . import exc
 from .util import run_before_script
@@ -137,7 +138,12 @@ class WorkspaceBuilder(object):
                     'Session name %s is already running.' % self.sconf['session_name']
                 )
             else:
-                self.sconf['start_directory'] = self.sconf.get('start_directory', None)
+                if not has_version('1.8'):
+                    self.sconf['start_directory'] = self.sconf.get(
+                        'start_directory', None
+                    )
+                else:
+                    self.sconf['start_directory'] = None
 
                 session = self.server.new_session(
                     session_name=self.sconf['session_name'],

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -137,6 +137,8 @@ class WorkspaceBuilder(object):
                     'Session name %s is already running.' % self.sconf['session_name']
                 )
             else:
+                self.sconf['start_directory'] = self.sconf.get('start_directory', None)
+
                 session = self.server.new_session(
                     session_name=self.sconf['session_name'],
                     start_directory=self.sconf['start_directory'],


### PR DESCRIPTION
This will make tmux's whole session be in a given directory, instead of just changing windows and panes' relative paths