### PR TITLE
start tests sessions with a blank config and /bin/sh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '2.7', '3.x' ]
-        tmux-version: [ '2.6', '2.7', '2.8', '3.0a', '3.1b', 'master' ]
+        tmux-version: [ '2.6', '2.7', '2.8', '3.0a', '3.1b', '3.2a', 'master' ]
     steps:
     - uses: actions/checkout@v1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,14 @@ def session(server):
     session_name = 'tmuxp'
 
     if not server.has_session(session_name):
-        server.cmd('new-session', '-d', '-s', session_name)
+        server.cmd(
+            '-f', '/dev/null',  # use a blank config to reduce side effects
+            'new-session',
+            '-d',  # detached
+            '-s', session_name,
+            '/bin/sh',  # use /bin/sh as a shell to reduce side effects
+                        # normally, it'd be -c, but new-session is special
+        )
 
     # find current sessions prefixed with tmuxp
     old_test_sessions = [


### PR DESCRIPTION
I don't think the ``/bin/sh`` carries through to new sessions though.