### PR TITLE
Add --combine flag to "load"

### DIFF
--- a/tmuxp/__about__.py
+++ b/tmuxp/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'tmuxp'
 __package_name__ = 'tmuxp'
-__version__ = '1.4.0'
+__version__ = '1.4.1b'
 __description__ = 'tmux session manager'
 __email__ = 'tony@git-pull.com'
 __author__ = 'Tony Narlock'


### PR DESCRIPTION
Hi guys,
the implementation works for my simple use case but probably needs more thought & some tests. Please treat this rather as a proposal of an idea than a mergable PR.

My use case: I sometimes work just on my laptop screen, sometimes I have an external screen. Depending on the situation I would like to start some tmux windows within the same or in two different sessions. I thus created two tmuxp config files. In the single-screen case I would like to combine the files into one config and start it as one session.

I added the "--combine" flag which takes all the given configs, combines them in a temporary config file and loads that one.

What do you think of the idea? If you think it is worthwhile, I will add tests and try to make the config merge bulletproof. If you don't, I will just use my fork and save the effort of making it usable for everyone :-)

Cheers,
Martin