### PR TITLE
Bump line-length 100 -> 88

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 exclude = .*/,.tox,*.egg,tmuxp/_compat.py,tmuxp/__*__.py,
 select = E,W,F,N
-max-line-length = 100
+max-line-length = 88
 # Stuff we ignore thanks to black: https://github.com/ambv/black/issues/429
 ignore = E111,
          E121,
@@ -52,5 +52,5 @@ known_pytest = pytest,py
 known_first_party = libtmux,tmuxp
 split_before_closing_bracket = true
 sections = FUTURE,STDLIB,PYTEST,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-line_length = 100
+line_length = 88
 not_skip = __init__.py


### PR DESCRIPTION
It went from 79 -> 100 in an earlier commit today.

Bring it down to 88, which is black's automatic setting.