### PR TITLE
pytest encoding fixes for python 2 + unicode_literals

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Test for tmuxp command line interface."""
-
 from __future__ import absolute_import
 
 import json
@@ -116,13 +115,13 @@ def projectdir(homedir):
 
 
 def test_tmuxp_configdir_env_var(tmpdir, monkeypatch):
-    monkeypatch.setenv('TMUXP_CONFIGDIR', tmpdir)
+    monkeypatch.setenv('TMUXP_CONFIGDIR', str(tmpdir))
 
     assert get_config_dir() == tmpdir
 
 
 def test_resolve_dot(tmpdir, homedir, configdir, projectdir, monkeypatch):
-    monkeypatch.setenv('HOME', homedir)
+    monkeypatch.setenv('HOME', str(homedir))
     projectdir.join('.tmuxp.yaml').ensure()
     user_config_name = 'myconfig'
     user_config = configdir.join('%s.yaml' % user_config_name).ensure()
@@ -226,7 +225,7 @@ def test_scan_config_arg(homedir, configdir, projectdir, monkeypatch):
     def config_cmd(config):
         click.echo(config)
 
-    monkeypatch.setenv('HOME', homedir)
+    monkeypatch.setenv('HOME', str(homedir))
     projectdir.join('.tmuxp.yaml').ensure()
     user_config_name = 'myconfig'
     user_config = configdir.join('%s.yaml' % user_config_name).ensure()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -356,7 +356,7 @@ def test_replaces_env_variables(monkeypatch):
 
     sconfig = load_yaml(yaml_config)
 
-    monkeypatch.setenv(env_key, env_val)
+    monkeypatch.setenv(str(env_key), str(env_val))
     sconfig = config.expand(sconfig)
     assert "%s/test" % env_val == sconfig['start_directory']
     assert "%s/test2" % env_val in sconfig['shell_command_before']

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -219,11 +219,11 @@ def test_global_options(session):
 
 def test_global_session_env_options(session, monkeypatch):
     visual_silence = 'on'
-    monkeypatch.setenv('VISUAL_SILENCE', visual_silence)
+    monkeypatch.setenv(str('VISUAL_SILENCE'), str(visual_silence))
     repeat_time = 738
-    monkeypatch.setenv('REPEAT_TIME', repeat_time)
+    monkeypatch.setenv(str('REPEAT_TIME'), str(repeat_time))
     main_pane_height = 8
-    monkeypatch.setenv('MAIN_PANE_HEIGHT', main_pane_height)
+    monkeypatch.setenv(str('MAIN_PANE_HEIGHT'), str(main_pane_height))
 
     yaml_config = loadfixture("workspacebuilder/env_var_options.yaml")
     s = session


### PR DESCRIPTION
This warning was introduced in pytest 3.8.2. For more information,
see the pull request at https://github.com/pytest-dev/pytest/pull/4056.