### PR TITLE
set window focus fix

### DIFF
--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -168,8 +168,8 @@ def set_layout_hook(session, hook_name):
         # with the client
         hook_cmd.append('selectw -t {}'.format(window.id))
         # edit: removed -t, or else it won't respect main-pane-w/h
-        hook_cmd.append('selectl'.format(window.id))
-        hook_cmd.append('selectw -p'.format(window.id))
+        hook_cmd.append('selectw -l {}'.format(window.id))
+        hook_cmd.append('selectw -p {}'.format(window.id))
 
     # unset the hook immediately after executing
     hook_cmd.append(

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -168,8 +168,8 @@ def set_layout_hook(session, hook_name):
         # with the client
         hook_cmd.append('selectw -t {}'.format(window.id))
         # edit: removed -t, or else it won't respect main-pane-w/h
-        hook_cmd.append('selectw -l {}'.format(window.id))
-        hook_cmd.append('selectw -p {}'.format(window.id))
+        hook_cmd.append('selectl')
+        hook_cmd.append('selectw -l')
 
     # unset the hook immediately after executing
     hook_cmd.append(


### PR DESCRIPTION
Fixes #326.

Existing hook sets focus to some window, but it does not set the focus back to the *last* (previously selected) window, but to the *previous* window (previous in the list of windows in the session).

My commit fixes this without any deeper knowledge about the hook itself.

Unfortunately the hook tells "no last window" to me now.