### PR TITLE
Fix docs

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -10,11 +10,17 @@ Command Line Interface
 Completion
 ----------
 
-In zsh (``~/.zshrc``) or bash (``~/.bashrc``):
+In bash (``~/.bashrc``):
 
 .. code-block:: sh
 
     eval "$(_TMUXP_COMPLETE=source tmuxp)"
+
+In zsh (``~/.zshrc``):
+
+.. code-block:: sh
+
+    eval "$(_TMUXP_COMPLETE=source_zsh tmuxp)"
 
 .. _cli_freeze:
 


### PR DESCRIPTION
According [click documentation](https://click.palletsprojects.com/en/7.x/bashcomplete/#activation) we should use `source_zsh` for zsh completion.

This will close #477.