### PR TITLE
Load config appending windows in current active session

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -18,7 +18,6 @@ Internals
 CLI
 ---
 
-.. automethod:: tmuxp.cli._reattach
 .. automethod:: tmuxp.cli.get_config_dir
 .. automethod:: tmuxp.cli.get_teamocil_dir
 .. automethod:: tmuxp.cli.get_tmuxinator_dir

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -84,6 +84,24 @@ without being attached. The last one will be attached if there is no
 
     $ tmuxp load <filename1> <filename2> ...
 
+If you try to load a config file within a tmux session, it will ask you
+if you want to load and attach in the new session or just load detached.
+You can also load config appending windows in the current active session.
+
+::
+
+    Already inside TMUX, switch to session? yes/no
+    Or (a)ppend windows in the current active session?
+    [y/n/a]:
+
+All this modes you can force doing:
+
+.. code-block:: bash
+
+    $ tmuxp load -y config # load attached
+    $ tmuxp load -d config # load detached
+    $ tmuxp load -a config # load appending
+
 .. _cli_import:
 
 Import

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -55,7 +55,8 @@ Load multiple tmux sessions at once:
     $ tmuxp load example.yaml anothersession.yaml
 
 tmuxp will offer to ``switch-client`` for you if you're already in a
-session.
+session. You can also load config appending windows in the current
+active session.
 
 You can also have a custom tmuxp config directory by setting the
 ``TMUX_CONFIGDIR`` in your environment variables.

--- a/tests/fixtures/workspacebuilder/three_windows.yaml
+++ b/tests/fixtures/workspacebuilder/three_windows.yaml
@@ -1,0 +1,15 @@
+session_name: sample_three_windows
+windows:
+- window_name: first
+  panes:
+    - shell_command:
+      - echo 'first window'
+- window_name: second
+  panes:
+    - shell_command:
+      - echo 'second window'
+- window_name: third
+  panes:
+    - shell_command:
+      - echo 'third window'
+

--- a/tests/fixtures/workspacebuilder/two_windows.yaml
+++ b/tests/fixtures/workspacebuilder/two_windows.yaml
@@ -1,0 +1,10 @@
+session_name: sample_two_windows
+windows:
+- window_name: first
+  panes:
+    - shell_command:
+      - echo 'first window'
+- window_name: second
+  panes:
+    - shell_command:
+      - echo 'second window'

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -692,7 +692,7 @@ def test_load_configs_same_session(server):
     sconfig = sconfig.import_config(yaml_config).get()
 
     builder = WorkspaceBuilder(sconf=sconfig, server=server)
-    builder.build(server.sessions[0])
+    builder.build(server.sessions[0], True)
 
     assert len(server.sessions) == 1
     assert len(server.sessions[0]._windows) == 5

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -673,3 +673,51 @@ def test_before_load_true_if_test_passes_with_args(server):
 
     with temp_session(server) as session:
         builder.build(session=session)
+
+
+def test_load_configs_same_session(server):
+    yaml_config = loadfixture("workspacebuilder/three_windows.yaml")
+    sconfig = kaptan.Kaptan(handler='yaml')
+    sconfig = sconfig.import_config(yaml_config).get()
+
+    builder = WorkspaceBuilder(sconf=sconfig, server=server)
+    builder.build()
+
+    assert len(server.sessions) == 1
+    assert len(server.sessions[0]._windows) == 3
+
+    yaml_config = loadfixture("workspacebuilder/two_windows.yaml")
+
+    sconfig = kaptan.Kaptan(handler='yaml')
+    sconfig = sconfig.import_config(yaml_config).get()
+
+    builder = WorkspaceBuilder(sconf=sconfig, server=server)
+    builder.build(server.sessions[0])
+
+    assert len(server.sessions) == 1
+    assert len(server.sessions[0]._windows) == 5
+
+
+def test_load_configs_separate_sessions(server):
+    yaml_config = loadfixture("workspacebuilder/three_windows.yaml")
+    sconfig = kaptan.Kaptan(handler='yaml')
+    sconfig = sconfig.import_config(yaml_config).get()
+
+    builder = WorkspaceBuilder(sconf=sconfig, server=server)
+    builder.build()
+
+    assert len(server.sessions) == 1
+    assert len(server.sessions[0]._windows) == 3
+
+    yaml_config = loadfixture("workspacebuilder/two_windows.yaml")
+
+    sconfig = kaptan.Kaptan(handler='yaml')
+    sconfig = sconfig.import_config(yaml_config).get()
+
+    builder = WorkspaceBuilder(sconf=sconfig, server=server)
+    builder.build()
+
+    assert len(server.sessions) == 2
+    assert len(server.sessions[0]._windows) == 3
+    assert len(server.sessions[1]._windows) == 2
+

--- a/tmuxp/__about__.py
+++ b/tmuxp/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'tmuxp'
 __package_name__ = 'tmuxp'
-__version__ = '1.5.3'
+__version__ = '1.6.0'
 __description__ = 'tmux session manager'
 __email__ = 'tony@git-pull.com'
 __author__ = 'Tony Narlock'

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -587,7 +587,7 @@ def load_append_windows_same_session(builder):
         Load configs in the active session appending windows
     """
     current_attached_sesssion = builder.find_current_attached_session()
-    builder.build(current_attached_sesssion)
+    builder.build(current_attached_sesssion, True)
     if has_gte_version('2.6'):  # prepare for both cases
         set_layout_hook(builder.session, 'client-attached')
         set_layout_hook(builder.session, 'client-session-changed')

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -368,29 +368,6 @@ def scan_config(config, config_dir=None):
     return config
 
 
-def _reattach(session):
-    """
-    Reattach session (depending on env being inside tmux already or not)
-
-    Parameters
-    ----------
-    session : :class:`libtmux.Session`
-
-    Notes
-    -----
-    If ``TMUX`` environmental variable exists in the environment this script is
-    running, that means we're in a tmux client. So ``tmux switch-client`` will
-    load the session.
-
-    If not, ``tmux attach-session`` loads the client to the target session.
-    """
-    if 'TMUX' in os.environ:
-        session.switch_client()
-
-    else:
-        session.attach_session()
-
-
 def load_workspace(
     config_file,
     socket_name=None,
@@ -510,20 +487,6 @@ def load_workspace(
         return
 
     session_name = sconfig['session_name']
-
-    # if the session already exists, prompt the user to attach. tmuxp doesn't
-    # support incremental session building or appending (yet, PR's welcome!)
-    if builder.session_exists(session_name):
-        if not detached and (
-            answer_yes
-            or click.confirm(
-                '%s is already running. Attach?'
-                % click.style(session_name, fg='green'),
-                default=True,
-            )
-        ):
-            _reattach(builder.session)
-        return
 
     try:
         click.echo(

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -486,8 +486,6 @@ def load_workspace(
         click.echo('%s is empty or parsed no config data' % config_file, err=True)
         return
 
-    session_name = sconfig['session_name']
-
     try:
         click.echo(
             click.style('[Loading] ', fg='green')
@@ -495,7 +493,8 @@ def load_workspace(
         )
 
         if 'TMUX' in os.environ:  # tmuxp ran from inside tmux
-            msg = 'Already inside TMUX, \n(a)ttach, (d)etach in a new session or append windows in (c)urrent session?\n[a/d/c]'
+            msg = "Already inside TMUX, \n(a)ttach, (d)etach in a new session "\
+            "or append windows in (c)urrent session?\n[a/d/c]"
             options = ['a', 'd', 'c']
             choice = click.prompt(msg, value_proc=_validate_choices(options))
 

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -500,7 +500,7 @@ def load_workspace(
             choice = click.prompt(msg, value_proc=_validate_choices(options))
 
             if not detached and choice == 'a':
-                builder.build()  # load tmux session via workspace builder
+                builder.build()  # load config in a new session and attach
 
                 # unset TMUX, save it, e.g. '/tmp/tmux-1000/default,30668,0'
                 tmux_env = os.environ.pop('TMUX')
@@ -519,14 +519,14 @@ def load_workspace(
                 if has_gte_version('2.6'):  # prepare for both cases
                     set_layout_hook(builder.session, 'client-attached')
                     set_layout_hook(builder.session, 'client-session-changed')
-            else:
+            else: # load config in a new detached session
                 builder.build()
                 if has_gte_version('2.6'):  # prepare for both cases
                     set_layout_hook(builder.session, 'client-attached')
                     set_layout_hook(builder.session, 'client-session-changed')
                 sys.exit('Session created in detached state.')
         else:
-            builder.build()  # load tmux session via workspace builder
+            builder.build() # load config in a new session
 
             if has_gte_version('2.6'):
                 # if attaching for first time

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -531,12 +531,13 @@ def load_workspace(
             + click.style(config_file, fg='blue', bold=True)
         )
 
-        builder.build()  # load tmux session via workspace builder
 
         if 'TMUX' in os.environ:  # tmuxp ran from inside tmux
             if not detached and (
                 answer_yes or click.confirm('Already inside TMUX, switch to session?')
             ):
+                builder.build()  # load tmux session via workspace builder
+
                 # unset TMUX, save it, e.g. '/tmp/tmux-1000/default,30668,0'
                 tmux_env = os.environ.pop('TMUX')
 
@@ -547,13 +548,19 @@ def load_workspace(
 
                 os.environ['TMUX'] = tmux_env  # set TMUX back again
                 return builder.session
-            else:  # session created in the background, from within tmux
+            else: # windows created in the same session
+                current_attached_sesssion = builder.find_current_attached_session()
+                builder.build(current_attached_sesssion)
+
                 if has_gte_version('2.6'):  # prepare for both cases
                     set_layout_hook(builder.session, 'client-attached')
                     set_layout_hook(builder.session, 'client-session-changed')
 
                 sys.exit('Session created in detached state.')
         else:  # tmuxp ran from inside tmux
+
+            builder.build()  # load tmux session via workspace builder
+
             if has_gte_version('2.6'):
                 # if attaching for first time
                 set_layout_hook(builder.session, 'client-attached')

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -211,6 +211,9 @@ class WorkspaceBuilder(object):
         ----------
         session : :class:`libtmux.Session`
             session to create windows in
+        append_same_sassion : bool
+            trick to identify previous open session and create
+            windows appending in the current session. default False.
 
         Returns
         -------

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -98,7 +98,7 @@ class WorkspaceBuilder(object):
 
         self.sconf = sconf
 
-    def build(self, session=None):
+    def build(self, session=None, append=False):
         """
         Build tmux workspace in session.
 
@@ -112,9 +112,10 @@ class WorkspaceBuilder(object):
         ----------
         session : :class:`libtmux.Session`
             session to build workspace in
+        append : bool
+            append windows in current active session
         """
 
-        self.previous_session = False
         if not session:
             if not self.server:
                 raise exc.TmuxpException(
@@ -136,8 +137,6 @@ class WorkspaceBuilder(object):
 
             assert self.sconf['session_name'] == session.name
             assert len(self.sconf['session_name']) > 0
-        else:
-            self.previous_session = True
 
         self.session = session
         self.server = session.server
@@ -172,8 +171,7 @@ class WorkspaceBuilder(object):
             for option, value in self.sconf['environment'].items():
                 self.session.set_environment(option, value)
 
-        append_windows = self.append_windows_same_session()
-        for w, wconf in self.iter_create_windows(session, append_windows):
+        for w, wconf in self.iter_create_windows(session, append):
             assert isinstance(w, Window)
 
             focus_pane = None
@@ -359,9 +357,6 @@ class WorkspaceBuilder(object):
 
     def first_window_pass(self, i, session, append_same_sassion):
         return len(session.windows) == 1 and i == 1 and not append_same_sassion
-
-    def append_windows_same_session(self):
-        return self.previous_session
 
 
 def freeze(session):

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -114,7 +114,7 @@ class WorkspaceBuilder(object):
             session to build workspace in
         """
 
-        previous_session = False
+        self.previous_session = False
         if not session:
             if not self.server:
                 raise exc.TmuxpException(
@@ -137,7 +137,7 @@ class WorkspaceBuilder(object):
             assert self.sconf['session_name'] == session.name
             assert len(self.sconf['session_name']) > 0
         else:
-            previous_session = True
+            self.previous_session = True
 
         self.session = session
         self.server = session.server
@@ -172,7 +172,7 @@ class WorkspaceBuilder(object):
             for option, value in self.sconf['environment'].items():
                 self.session.set_environment(option, value)
 
-        for w, wconf in self.iter_create_windows(session):
+        for w, wconf in self.iter_create_windows(session, self.append_windows_same_session()):
             assert isinstance(w, Window)
 
             focus_pane = None
@@ -197,7 +197,7 @@ class WorkspaceBuilder(object):
         if focus:
             focus.select_window()
 
-    def iter_create_windows(self, session, previous_session=False):
+    def iter_create_windows(self, session, append_same_sassion=False):
         """
         Return :class:`libtmux.Window` iterating through session config dict.
 
@@ -223,7 +223,7 @@ class WorkspaceBuilder(object):
             else:
                 window_name = wconf['window_name']
 
-            is_first_window_pass = self.first_window_pass(i, session, previous_session)
+            is_first_window_pass = self.first_window_pass(i, session, append_same_sassion)
 
             w1 = None
             if is_first_window_pass: # if first window, use window 1
@@ -351,8 +351,11 @@ class WorkspaceBuilder(object):
     def find_current_attached_session(self):
         return self.server.list_sessions()[0]
 
-    def first_window_pass(self, i, session, previous_session):
-        return len(session.windows) == 1 and i == 1 and not previous_session
+    def first_window_pass(self, i, session, append_same_sassion):
+        return len(session.windows) == 1 and i == 1 and not append_same_sassion
+
+    def append_windows_same_session(self):
+        return self.previous_session
 
 
 def freeze(session):

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -172,7 +172,8 @@ class WorkspaceBuilder(object):
             for option, value in self.sconf['environment'].items():
                 self.session.set_environment(option, value)
 
-        for w, wconf in self.iter_create_windows(session, self.append_windows_same_session()):
+        append_windows = self.append_windows_same_session()
+        for w, wconf in self.iter_create_windows(session, append_windows):
             assert isinstance(w, Window)
 
             focus_pane = None
@@ -223,7 +224,9 @@ class WorkspaceBuilder(object):
             else:
                 window_name = wconf['window_name']
 
-            is_first_window_pass = self.first_window_pass(i, session, append_same_sassion)
+            is_first_window_pass = self.first_window_pass(
+                i, session, append_same_sassion
+            )
 
             w1 = None
             if is_first_window_pass: # if first window, use window 1

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -122,7 +122,7 @@ class WorkspaceBuilder(object):
             session to build workspace in
         """
 
-        self.previous_session = False
+        previous_session = False
         if not session:
             if not self.server:
                 raise exc.TmuxpException(
@@ -145,7 +145,7 @@ class WorkspaceBuilder(object):
             assert self.sconf['session_name'] == session.name
             assert len(self.sconf['session_name']) > 0
         else:
-            self.previous_session = True
+            previous_session = True
 
         self.session = session
         self.server = session.server
@@ -205,7 +205,7 @@ class WorkspaceBuilder(object):
         if focus:
             focus.select_window()
 
-    def iter_create_windows(self, session):
+    def iter_create_windows(self, session, previous_session=False):
         """
         Return :class:`libtmux.Window` iterating through session config dict.
 
@@ -231,10 +231,9 @@ class WorkspaceBuilder(object):
             else:
                 window_name = wconf['window_name']
 
-            is_first_window_pass = self.first_window_pass(i)
+            is_first_window_pass = self.first_window_pass(i, session, previous_session)
 
             w1 = None
-            #if i == int(1):
             if is_first_window_pass: # if first window, use window 1
                 w1 = session.attached_window
                 w1.move_window(99)
@@ -360,8 +359,8 @@ class WorkspaceBuilder(object):
     def find_current_attached_session(self):
         return self.server.list_sessions()[0]
 
-    def first_window_pass(self, i):
-        return len(self.session.windows) == 1 and i == 1 and not self.previous_session
+    def first_window_pass(self, i, session, previous_session):
+        return len(session.windows) == 1 and i == 1 and not previous_session
 
 
 def freeze(session):

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -98,14 +98,6 @@ class WorkspaceBuilder(object):
 
         self.sconf = sconf
 
-    def session_exists(self, session_name=None):
-        exists = self.server.has_session(session_name)
-        if not exists:
-            return exists
-
-        self.session = self.server.find_where({'session_name': session_name})
-        return True
-
     def build(self, session=None):
         """
         Build tmux workspace in session.


### PR DESCRIPTION
I see some people requesting this feature (me included) https://github.com/tmux-python/tmuxp/issues/289 https://github.com/tmux-python/tmuxp/issues/373 and some even tried to add this functionality https://github.com/tmux-python/tmuxp/pull/374 https://github.com/tmux-python/tmuxp/pull/407 but those ideas never went from draft.

I decided to implement this feature maintaining the compatibility with features we already have (open attached and detached). The motivation to this feature is because I feel more productive seen everything I have opened as visible windows. I tried to use several sessions and **switch-sessions** using tmux shortcut _C-b s_ but I didn't get use to it (maybe I will try again in the future).

Summarizing what this PR adds:
When you try to **load** a config file within a current open tmux session it will ask you if you want to: 

1. create a new session and attach?
2. create a new session and detach?
3. load config appending windows in the current active session?

To maintain the compatibility I didn't change the question, I just added another option to the user.
> Already inside TMUX, switch to session? yes/no
Or (a)ppend windows in the current active session?
[y/n/a]:

If you anwser:
**Yes** it will attach
**No** will detach
**Append** will append windows in the same session

I also added the ability to _force append_ using the CLI:
`$ tmuxp load -a config`

I hope to see this feature in **tmuxp**. Who else's want? :point_up_2:
