### PR TITLE
fixed entr_warn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PY_FILES= find . -type f -not -path '*/\.*' | grep -i '.*[.]py$$' 2> /dev/null
 
-entr_warn: @echo "----------------------------------------------------------"
+entr_warn: 
+	@echo "----------------------------------------------------------"
 	@echo "     ! File watching functionality non-operational !      "
 	@echo "                                                          "
 	@echo "Install entr(1) to automatically run tasks on file change."


### PR DESCRIPTION
make: *** No rule to make target `@echo', needed by `entr_warn'.  Stop.