### PR TITLE
Allow overwrite on freeze

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -491,6 +491,14 @@ def test_import_tmuxinator(cli_args, inputs, tmpdir, monkeypatch):
             ['\n', 'y\n', './la.yaml\n', 'y\n'],
         ),
         (['freeze'], ['\n', 'y\n', './exists.yaml\n', './la.yaml\n', 'y\n']),  # Exists
+        (  # Create a new one
+            ['freeze', 'mysession', '--force'],
+            ['\n', 'y\n', './la.yaml\n', 'y\n']
+        ),
+        (  # Imply current session if not entered
+            ['freeze', '--force'],
+            ['\n', 'y\n', './la.yaml\n', 'y\n'],
+        ),
     ],
 )
 def test_freeze(server, cli_args, inputs, tmpdir, monkeypatch):
@@ -506,6 +514,34 @@ def test_freeze(server, cli_args, inputs, tmpdir, monkeypatch):
         out = runner.invoke(cli.cli, cli_args, input=''.join(inputs))
         print(out.output)
         assert tmpdir.join('la.yaml').check()
+
+
+@pytest.mark.parametrize(
+    "cli_args,inputs",
+    [
+        (  # Overwrite
+            ['freeze', 'mysession', '--force'],
+            ['\n', 'y\n', './exists.yaml\n', 'y\n'],
+        ),
+        (  # Imply current session if not entered
+            ['freeze', '--force'],
+            ['\n', 'y\n', './exists.yaml\n', 'y\n']
+        ),
+    ],
+)
+def test_freeze_overwrite(server, cli_args, inputs, tmpdir, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmpdir))
+    tmpdir.join('exists.yaml').ensure()
+
+    server.new_session(session_name='mysession')
+
+    with tmpdir.as_cwd():
+        runner = CliRunner()
+        # Use tmux server (socket name) used in the test
+        cli_args = cli_args + ['-L', server.socket_name]
+        out = runner.invoke(cli.cli, cli_args, input=''.join(inputs))
+        print(out.output)
+        assert tmpdir.join('exists.yaml').check()
 
 
 def test_get_abs_path(tmpdir):

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -659,7 +659,8 @@ def startup(config_dir):
 @click.argument('session_name', nargs=1, required=False)
 @click.option('-S', 'socket_path', help='pass-through for tmux -S')
 @click.option('-L', 'socket_name', help='pass-through for tmux -L')
-def command_freeze(session_name, socket_name, socket_path):
+@click.option('--force', 'force', help='overwrite the config file', is_flag=True)
+def command_freeze(session_name, socket_name, socket_path, force):
     """Snapshot a session into a config.
 
     If SESSION_NAME is provided, snapshot that session. Otherwise, use the
@@ -716,7 +717,7 @@ def command_freeze(session_name, socket_name, socket_path):
             dest_prompt = click.prompt(
                 'Save to: %s' % save_to, value_proc=get_abs_path, default=save_to
             )
-            if os.path.exists(dest_prompt):
+            if not force and os.path.exists(dest_prompt):
                 print('%s exists. Pick a new filename.' % dest_prompt)
                 continue
 


### PR DESCRIPTION
As mentioned in #64 and #537 it would be nice to have an option to overwrite the config file.

This will give the `freeze` command a new option to overwrite the configuration file.

```
tmuxp freeze --force <session_name>
```