### PR TITLE
Added "-y" Option to convert command to directly convert the config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,100 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # Don't run twice for internal PRs from our own repo
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '2.7', '3.x' ]
+        tmux-version: [ '2.6', '2.7', '2.8', '3.0', 'master' ]
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Get full Python version
+      id: full-python-version
+      shell: bash
+      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+    - name: Install poetry
+      run: |
+        curl -O -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py
+        python get-poetry.py -y
+        echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+        rm get-poetry.py
+
+    - name: Get poetry cache paths from config
+      run: |
+        echo ::set-env name=poetry_cache_dir::$(poetry config --list | sed -n 's/.*cache-dir = //p' | sed -e 's/^"//' -e 's/"$//')
+        echo ::set-env name=poetry_virtualenvs_path::$(poetry config --list | sed -n 's/.*virtualenvs.path = .* # //p' | sed -e 's/^"//' -e 's/"$//')
+
+    - name: Configure poetry
+      shell: bash
+      run: poetry config virtualenvs.in-project true
+
+    - name: Set up poetry cache
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: |
+          .venv
+          {{ env.poetry_cache_dir }}
+          {{ env.poetry_virtualenvs_path }}
+        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Ensure cache is healthy
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
+
+    - name: Setup tmux build cache for tmux ${{ matrix.tmux-version }}
+      id: tmux-build-cache
+      uses: actions/cache@v1
+      with:
+        path: ~/tmux-builds/tmux-${{ matrix.tmux-version }}
+        key: tmux-${{ matrix.tmux-version }}
+
+    - name: Build tmux ${{ matrix.tmux-version }}
+      if: steps.tmux-build-cache.outputs.cache-hit != 'true'
+      run: |
+        sudo apt install libevent-dev libncurses5-dev libtinfo-dev libutempter-dev bison
+        mkdir ~/tmux-builds
+        mkdir ~/tmux-src
+        git clone https://github.com/tmux/tmux.git ~/tmux-src/tmux-${{ matrix.tmux-version }}
+        cd ~/tmux-src/tmux-${{ matrix.tmux-version }}
+        git checkout ${{ matrix.tmux-version }}
+        sh autogen.sh
+        ./configure --prefix=$HOME/tmux-builds/tmux-${{ matrix.tmux-version }} && make && make install
+        export PATH=$HOME/tmux-builds/tmux-${{ matrix.tmux-version }}/bin:$PATH
+        cd ~
+        tmux -V
+
+    - name: Upgrade pip
+      shell: bash
+      run: poetry run python -m pip install pip -U
+
+    - name: Install python dependencies
+      run: |
+        poetry install -E "test coverage lint"
+    - name: Lint with flake8
+      run: |
+        poetry run flake8
+    - name: Test with pytest
+      continue-on-error: ${{ matrix.tmux-version == 'master' }}
+      run: |
+        export PATH=$HOME/tmux-builds/tmux-${{ matrix.tmux-version }}/bin:$PATH
+        ls $HOME/tmux-builds/tmux-${{ matrix.tmux-version }}/bin
+        tmux -V
+        poetry run py.test --cov=./ --cov-report=xml
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Here you can find the recent changes to tmuxp
 
 current
 -------
+- :issue:`589` added option for the the confirm command to auto-confirm the prompt.
 - :issue:`623` Move docs from RTD to self-serve site
 - :issue:`623` Modernize Makefiles
 - :issue:`623` New development docs

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,8 @@ current
 - :issue:`623` Move docs from RTD to self-serve site
 - :issue:`623` Modernize Makefiles
 - :issue:`623` New development docs
+- :issue:`623` Move doc -> docs
+- :issue:`623` Move tests to GitHub Actions
 - :issue:`623` Update pyproject.toml to experiment with poetry packaging
 - :issue:`619` isort 5
 

--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,28 @@ Snapshot your tmux layout, pane paths, and window/session names.
 
 See more about `freezing tmux`_ sessions.
 
+
+Convert a session file
+----------------------
+
+Convert a session file from yaml to json and vice versa.
+
+.. code-block:: sh
+
+   $ tmuxp convert filename
+
+This will prompt you for confirmation and shows you the new file that is going
+to be written.
+
+
+You can auto confirm the prompt. In this case no preview will be shown.
+
+.. code-block:: sh
+
+   $ tmuxp convert -y filename
+   $ tmuxp convert --yes filename
+
+
 Docs / Reading material
 -----------------------
 

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -898,12 +898,14 @@ def command_import_tmuxinator(configfile):
 
 
 @cli.command(name='convert')
+@click.option('--yes', '-y', 'confirmed', help='Auto confirms with "yes".', 
+              is_flag=True)
 @click.argument('config', type=ConfigPath(exists=True), nargs=1)
-def command_convert(config):
+def command_convert(confirmed, config):
     """Convert a tmuxp config between JSON and YAML."""
 
     _, ext = os.path.splitext(config)
-    if 'json' in ext:
+    if 'json' in ext and not confirmed:
         if click.confirm('convert to <%s> to yaml?' % config):
             configparser = kaptan.Kaptan()
             configparser.import_config(config)
@@ -914,7 +916,7 @@ def command_convert(config):
                 buf.write(newconfig)
                 buf.close()
                 print('New config saved to %s' % newfile)
-    elif 'yaml' in ext:
+    elif 'yaml' in ext and not confirmed:
         if click.confirm('convert to <%s> to json?' % config):
             configparser = kaptan.Kaptan()
             configparser.import_config(config)
@@ -926,6 +928,24 @@ def command_convert(config):
                 buf.write(newconfig)
                 buf.close()
                 print('New config saved to <%s>.' % newfile)
+    elif 'json' in ext and confirmed:
+        configparser = kaptan.Kaptan()
+        configparser.import_config(config)
+        newfile = config.replace(ext, '.yaml')
+        newconfig = configparser.export('yaml', indent=2, default_flow_style=False)
+        buf = open(newfile, 'w')
+        buf.write(newconfig)
+        buf.close()
+        print('New config saved to <%s>.' % newfile)
+    elif 'yaml' in ext and confirmed:
+        configparser = kaptan.Kaptan()
+        configparser.import_config(config)
+        newfile = config.replace(ext, '.json')
+        newconfig = configparser.export('json', indent=2)
+        buf = open(newfile, 'w')
+        buf.write(newconfig)
+        buf.close()
+        print('New config saved to <%s>.' % newfile)
 
 
 @cli.command(


### PR DESCRIPTION
I implemented the feature requested in #589. I ran all test except the one described in issue #620. 

I extensively tested the feature with a a lot of configs. I went with "-y" like requested in #589 but maybe it would be more concise to do `-f` / `--force` like PR #618 does with the freeze command.
