### PR TITLE
Adding commas to requirements/base.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 kaptan>=0.5.10
-libtmux>=0.8<0.9
-click>=7<8
+libtmux>=0.8,<0.9
+click>=7,<8
 colorama>=0.3.9


### PR DESCRIPTION
It was installing click 8.0.0.1a  Addresses #649

## My testing in a new virtualenv

### Original specification of click as in tmuxp's requirements/base.txt
$ cat requirements.txt
click>=7<8

$ pip install -r requirements.txt
Collecting click>=7<8
  Using cached click-8.0.0a1-py3-none-any.whl (89 kB)
Installing collected packages: click
Successfully installed **click-8.0.0a1**

### Edit to add the comma
$ cat requirements.txt
click>=7,<8

$ pip install -r requirements.txt
Collecting click<8,>=7
  Using cached click-7.1.2-py2.py3-none-any.whl (82 kB)
Installing collected packages: click
Successfully installed **click-7.1.2**
