### PR TITLE
Freeze config for attached session

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,12 +130,18 @@ my_window
 ## Freeze sessions
 
 ```
+tmuxp freeze
 tmuxp freeze <session_name>
+tmuxp freeze --force <session_name>
 ```
 
 You can save the state of your tmux session by freezing it.
 
 Tmuxp will offer to save your session state to `.json` or `.yaml`.
+
+If no session is specified, it will default to the attached session.
+
+If the `--force` argument is passed, it will overwrite any existing config file with the same name.
 
 (cli-load)=
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -889,9 +889,9 @@ def test_freeze(server, cli_args, inputs, tmpdir, monkeypatch):
 
     # Assign an active pane to the session
     second_session = server.list_sessions()[1]
-    first_pane_on_second_session_id = (
-        second_session.list_windows()[0].list_panes()[0]["pane_id"]
-    )
+    first_pane_on_second_session_id = second_session.list_windows()[0].list_panes()[0][
+        "pane_id"
+    ]
     monkeypatch.setenv("TMUX_PANE", first_pane_on_second_session_id)
 
     with tmpdir.as_cwd():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -64,7 +64,7 @@ def test_get_session_should_default_to_local_attached_session(server, monkeypatc
     assert get_session(server) == second_session
 
 
-def test_get_session_should_raise_exception_if_no_session(server):
+def test_get_session_should_return_first_session_if_no_active_session(server):
     first_session = server.new_session(session_name='myfirstsession')
     server.new_session(session_name='mysecondsession')
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,7 +5,7 @@ import pytest
 
 from tmuxp import exc
 from tmuxp.exc import BeforeLoadScriptError, BeforeLoadScriptNotExists
-from tmuxp.util import run_before_script
+from tmuxp.util import run_before_script, get_session
 
 from . import fixtures_dir
 
@@ -49,3 +49,23 @@ def test_beforeload_returns_stderr_messages():
     with pytest.raises(exc.BeforeLoadScriptError) as excinfo:
         run_before_script(script_file)
         assert excinfo.match(r'failed with returncode')
+
+
+def test_get_session_should_default_to_local_attached_session(server, monkeypatch):
+    server.new_session(session_name='myfirstsession')
+    second_session = server.new_session(session_name='mysecondsession')
+
+    # Assign an active pane to the session
+    first_pane_on_second_session_id = second_session.list_windows()[0].list_panes()[0][
+        'pane_id'
+    ]
+    monkeypatch.setenv('TMUX_PANE', first_pane_on_second_session_id)
+
+    assert get_session(server) == second_session
+
+
+def test_get_session_should_raise_exception_if_no_session(server):
+    first_session = server.new_session(session_name='myfirstsession')
+    server.new_session(session_name='mysecondsession')
+
+    assert get_session(server) == first_session

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,7 +5,7 @@ import pytest
 
 from tmuxp import exc
 from tmuxp.exc import BeforeLoadScriptError, BeforeLoadScriptNotExists
-from tmuxp.util import run_before_script, get_session
+from tmuxp.util import get_session, run_before_script
 
 from . import fixtures_dir
 

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -924,7 +924,7 @@ def command_freeze(session_name, socket_name, socket_path, force):
         if session_name:
             session = t.find_where({'session_name': session_name})
         else:
-            session = t.list_sessions()[0]
+            session = util.get_session(t)
 
         if not session:
             raise exc.TmuxpException('Session not found.')

--- a/tmuxp/util.py
+++ b/tmuxp/util.py
@@ -111,10 +111,17 @@ def get_session(server, session_name=None, current_pane=None):
     elif current_pane is not None:
         session = server.find_where({'session_id': current_pane['session_id']})
     else:
-        session = server.list_sessions()[0]
+        current_pane = get_current_pane(server)
+        if current_pane:
+            session = server.find_where({'session_id': current_pane['session_id']})
+        else:
+            session = server.list_sessions()[0]
 
     if not session:
-        raise exc.TmuxpException('Session not found: %s' % session_name)
+        if session_name:
+            raise exc.TmuxpException('Session not found: %s' % session_name)
+        else:
+            raise exc.TmuxpException('Session not found')
 
     return session
 

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -348,7 +348,7 @@ class WorkspaceBuilder(object):
                     attach=True,
                     start_directory=get_pane_start_directory(),
                     shell=get_pane_shell(),
-                    target=p.id
+                    target=p.id,
                 )
 
             assert isinstance(p, Pane)


### PR DESCRIPTION
This PR changes the behaviour of `tmuxp freeze` to default to the currently attached session. It achieves this by modifying the `get_session` utility function, will has the side effect of also modifying the behaviour of `tmuxp shell` to match - as this is the behaviour specified in the docs I believe it's probably fine and was just a bug.

Closes #659 