### PR TITLE
Append test plugin packages via `monkeypatch.syspath_prepend`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,12 +69,6 @@ pytest-mock = [
   {version="<3.0.0", python="<3"},
   {version="*", python=">=3"}
 ]
-tmuxp-test-plugin-bwb = { path = "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bwb/"}
-tmuxp-test-plugin-bs = { path = "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bs/"}
-tmuxp-test-plugin-r = { path = "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_r/"}
-tmuxp-test-plugin-owc = { path = "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_owc/"}
-tmuxp-test-plugin-awf = { path = "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_awf/"}
-tmuxp-test-plugin-fail = { path = "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_fail/"}
 
 ### Coverage ###
 codecov = "*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-
 import logging
+import os
 
 import pytest
 
@@ -9,6 +9,20 @@ from libtmux.server import Server
 from libtmux.test import TEST_SESSION_PREFIX, get_test_session_name, namer
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True, scope='function')
+def site_packages_test_fixtures(monkeypatch):
+    paths = [
+        "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bwb/",
+        "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bs/",
+        "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_r/",
+        "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_owc/",
+        "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_awf/",
+        "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_fail/",
+    ]
+    for path in paths:
+        monkeypatch.syspath_prepend(os.path.abspath(os.path.relpath(path)))
 
 
 @pytest.fixture(scope='function')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,8 @@ from libtmux.test import TEST_SESSION_PREFIX, get_test_session_name, namer
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture(autouse=True, scope='function')
-def site_packages_test_fixtures(monkeypatch):
+@pytest.fixture(scope='function')
+def monkeypatch_plugin_test_packages(monkeypatch):
     paths = [
         "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bwb/",
         "tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bs/",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,16 +15,15 @@ import pytest
 import click
 import kaptan
 from click.testing import CliRunner
-from tmuxp_test_plugin_bwb.plugin import PluginBeforeWorkspaceBuilder
 
 import libtmux
 from libtmux.common import has_lt_version
 from libtmux.exc import LibTmuxException
 from tmuxp import cli, config, exc
 from tmuxp.cli import (
-    _reattach,
-    _load_attached,
     _load_append_windows_to_current_session,
+    _load_attached,
+    _reattach,
     command_debug_info,
     command_ls,
     get_config_dir,
@@ -996,6 +995,8 @@ def test_ls_cli(monkeypatch, tmpdir):
 
 
 def test_load_plugins():
+    from tmuxp_test_plugin_bwb.plugin import PluginBeforeWorkspaceBuilder
+
     plugins_config = loadfixture("workspacebuilder/plugin_bwb.yaml")
 
     sconfig = kaptan.Kaptan(handler='yaml')
@@ -1174,6 +1175,7 @@ def test_load_attached_within_tmux_detached(server, monkeypatch):
 
     assert builder.session.switch_client.call_count == 1
 
+
 def test_load_append_windows_to_current_session(server, monkeypatch):
     yaml_config = loadfixture("workspacebuilder/two_pane.yaml")
     sconfig = kaptan.Kaptan(handler='yaml')
@@ -1193,7 +1195,6 @@ def test_load_append_windows_to_current_session(server, monkeypatch):
 
     assert len(server.list_sessions()) == 1
     assert len(server._list_windows()) == 6
-
 
 
 def test_debug_info_cli(monkeypatch, tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -994,7 +994,7 @@ def test_ls_cli(monkeypatch, tmpdir):
     assert cli_output == '\n'.join(stems) + '\n'
 
 
-def test_load_plugins():
+def test_load_plugins(monkeypatch_plugin_test_packages):
     from tmuxp_test_plugin_bwb.plugin import PluginBeforeWorkspaceBuilder
 
     plugins_config = loadfixture("workspacebuilder/plugin_bwb.yaml")
@@ -1024,7 +1024,9 @@ def test_load_plugins():
         )
     ],
 )
-def test_load_plugins_version_fail_skip(cli_args, inputs):
+def test_load_plugins_version_fail_skip(
+    monkeypatch_plugin_test_packages, cli_args, inputs
+):
     runner = CliRunner()
 
     results = runner.invoke(cli.cli, cli_args, input=''.join(inputs))
@@ -1040,7 +1042,9 @@ def test_load_plugins_version_fail_skip(cli_args, inputs):
         )
     ],
 )
-def test_load_plugins_version_fail_no_skip(cli_args, inputs):
+def test_load_plugins_version_fail_no_skip(
+    monkeypatch_plugin_test_packages, cli_args, inputs
+):
     runner = CliRunner()
 
     results = runner.invoke(cli.cli, cli_args, input=''.join(inputs))
@@ -1050,14 +1054,16 @@ def test_load_plugins_version_fail_no_skip(cli_args, inputs):
 @pytest.mark.parametrize(
     "cli_args", [(['load', 'tests/fixtures/workspacebuilder/plugin_missing_fail.yaml'])]
 )
-def test_load_plugins_plugin_missing(cli_args):
+def test_load_plugins_plugin_missing(monkeypatch_plugin_test_packages, cli_args):
     runner = CliRunner()
 
     results = runner.invoke(cli.cli, cli_args)
     assert '[Plugin Error]' in results.output
 
 
-def test_plugin_system_before_script(server, monkeypatch):
+def test_plugin_system_before_script(
+    monkeypatch_plugin_test_packages, server, monkeypatch
+):
     # this is an implementation test. Since this testsuite may be ran within
     # a tmux session by the developer himself, delete the TMUX variable
     # temporarily.
@@ -1073,7 +1079,7 @@ def test_plugin_system_before_script(server, monkeypatch):
     assert session.name == 'plugin_test_bs'
 
 
-def test_reattach_plugins(server):
+def test_reattach_plugins(monkeypatch_plugin_test_packages, server):
     config_plugins = loadfixture("workspacebuilder/plugin_r.yaml")
 
     sconfig = kaptan.Kaptan(handler='yaml')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -24,6 +24,11 @@ from .fixtures.pluginsystem.partials.tmuxp_version_fail import (
 )
 
 
+@pytest.fixture(autouse=True)
+def autopatch_sitedir(monkeypatch_plugin_test_packages):
+    pass
+
+
 def test_all_pass():
     AllVersionPassPlugin()
 

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -14,8 +14,8 @@ from libtmux.common import has_gte_version
 from libtmux.test import retry, temp_session
 from tmuxp import config, exc
 from tmuxp._compat import text_type
-from tmuxp.workspacebuilder import WorkspaceBuilder
 from tmuxp.cli import load_plugins
+from tmuxp.workspacebuilder import WorkspaceBuilder
 
 from . import example_dir, fixtures_dir
 from .fixtures._util import loadfixture
@@ -676,7 +676,9 @@ def test_before_load_true_if_test_passes_with_args(server):
         builder.build(session=session)
 
 
-def test_plugin_system_before_workspace_builder(session):
+def test_plugin_system_before_workspace_builder(
+    monkeypatch_plugin_test_packages, session
+):
     config_plugins = loadfixture("workspacebuilder/plugin_bwb.yaml")
 
     sconfig = kaptan.Kaptan(handler='yaml')
@@ -692,7 +694,7 @@ def test_plugin_system_before_workspace_builder(session):
     assert proc.stdout[0] == "'plugin_test_bwb'"
 
 
-def test_plugin_system_on_window_create(session):
+def test_plugin_system_on_window_create(monkeypatch_plugin_test_packages, session):
     config_plugins = loadfixture("workspacebuilder/plugin_owc.yaml")
 
     sconfig = kaptan.Kaptan(handler='yaml')
@@ -708,7 +710,7 @@ def test_plugin_system_on_window_create(session):
     assert proc.stdout[0] == "'plugin_test_owc'"
 
 
-def test_plugin_system_after_window_finished(session):
+def test_plugin_system_after_window_finished(monkeypatch_plugin_test_packages, session):
     config_plugins = loadfixture("workspacebuilder/plugin_awf.yaml")
 
     sconfig = kaptan.Kaptan(handler='yaml')
@@ -741,7 +743,9 @@ def test_plugin_system_on_window_create_multiple_windows(session):
     assert "'plugin_test_owc_mw_2'" in proc.stdout
 
 
-def test_plugin_system_after_window_finished_multiple_windows(session):
+def test_plugin_system_after_window_finished_multiple_windows(
+    monkeypatch_plugin_test_packages, session
+):
     config_plugins = loadfixture("workspacebuilder/plugin_awf_multiple_windows.yaml")
 
     sconfig = kaptan.Kaptan(handler='yaml')
@@ -758,7 +762,7 @@ def test_plugin_system_after_window_finished_multiple_windows(session):
     assert "'plugin_test_awf_mw_2'" in proc.stdout
 
 
-def test_plugin_system_multiple_plugins(session):
+def test_plugin_system_multiple_plugins(monkeypatch_plugin_test_packages, session):
     config_plugins = loadfixture("workspacebuilder/plugin_multiple_plugins.yaml")
 
     sconfig = kaptan.Kaptan(handler='yaml')
@@ -858,9 +862,9 @@ def test_find_current_active_pane(server, monkeypatch):
 
     # Assign an active pane to the session
     second_session = server.list_sessions()[1]
-    first_pane_on_second_session_id = (
-        second_session.list_windows()[0].list_panes()[0]["pane_id"]
-    )
+    first_pane_on_second_session_id = second_session.list_windows()[0].list_panes()[0][
+        "pane_id"
+    ]
     monkeypatch.setenv("TMUX_PANE", first_pane_on_second_session_id)
 
     builder = WorkspaceBuilder(sconf=sconfig, server=server)


### PR DESCRIPTION
Fixes #658 

- 1st commit : Applies monkey patch globally to all tests, removes test packages from `pyproject.toml`
- 2nd commit : Scopes it to only relevant packages, so unrelated tests don't have `sys.path`'s altered.

  This is optional, but good to ensure explicitness (down the road, implicit alteration of site packages for all tests may be super hard to track down if it leads to an error in tests years from now, so I try to use `autouse=True` sparingly as possible)
 
Any thoughts on this approach @joseph-flinn?