### PR TITLE
Add `shell`-configuration to pane layer

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -307,6 +307,26 @@ without `window_index` will use the lowest available window index.
 
 ```
 
+## Shell per pane
+
+Every pane can have its own shell or application started. This allows for usage
+of the ``remain-on-exit`` setting to be used properly, but also to have
+different shells on different panes.
+
+### YAML
+
+```{literalinclude} ../examples/pane-shell.yaml
+:language: yaml
+
+```
+
+### JSON
+
+```{literalinclude} ../examples/pane-shell.json
+:language: json
+
+```
+
 ## Set tmux options
 
 Works with global (server-wide) options, session options

--- a/examples/pane-shell.json
+++ b/examples/pane-shell.json
@@ -1,0 +1,40 @@
+{
+  "session_name": "Pane shell example",
+  "windows": [
+    {
+      "window_name": "first",
+      "window_shell": "/usr/bin/python2",
+      "layout": "even-vertical",
+      "suppress_history": false,
+      "options": {
+        "remain-on-exit": true
+      },
+      "panes": [
+        {
+          "shell": "/usr/bin/python3",
+          "shell_command": [
+            "print('This is python 3')"
+          ]
+        },
+        {
+          "shell": "/usr/bin/vim -u none",
+          "shell_command": [
+            "iAll panes have the `remain-on-exit` setting on.",
+            "When you exit out of the shell or application, the panes will remain.",
+            "Use tmux command `:kill-pane` to remove the pane.",
+            "Use tmux command `:respawn-pane` to restart the shell in the pane.",
+            "Use <Escape> and then `:q!` to get out of this vim window. :-)"
+          ]
+        },
+        {
+          "shell_command": [
+            "print('Hello World 2')"
+          ]
+        },
+        {
+          "shell": "/usr/bin/top"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/pane-shell.yaml
+++ b/examples/pane-shell.yaml
@@ -1,0 +1,22 @@
+session_name: Pane shell example
+windows:
+  - window_name: first
+    window_shell: /usr/bin/python2
+    layout: even-vertical
+    suppress_history: false
+    options:
+      remain-on-exit: true
+    panes:
+      - shell: /usr/bin/python3
+        shell_command:
+          - print('This is python 3')
+      - shell: /usr/bin/vim -u none
+        shell_command:
+          - iAll panes have the `remain-on-exit` setting on.
+          - When you exit out of the shell or application, the panes will remain.
+          - Use tmux command `:kill-pane` to remove the pane.
+          - Use tmux command `:respawn-pane` to restart the shell in the pane.
+          - Use <Escape> and then `:q!` to get out of this vim window. :-)
+      - shell_command:
+          - print('Hello World 2')
+      - shell: /usr/bin/top

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -265,6 +265,13 @@ class WorkspaceBuilder(object):
             else:
                 ws = None
 
+            # If the first pane specifies a shell, use that instead.
+            try:
+                if wconf['panes'][0]['shell'] != '':
+                    ws = wconf['panes'][0]['shell']
+            except (KeyError, IndexError):
+                pass
+
             w = session.new_window(
                 window_name=window_name,
                 start_directory=sd,
@@ -328,8 +335,20 @@ class WorkspaceBuilder(object):
                     else:
                         return None
 
+                def get_pane_shell():
+
+                    if 'shell' in pconf:
+                        return pconf['shell']
+                    elif 'window_shell' in wconf:
+                        return wconf['window_shell']
+                    else:
+                        return None
+
                 p = w.split_window(
-                    attach=True, start_directory=get_pane_start_directory(), target=p.id
+                    attach=True,
+                    start_directory=get_pane_start_directory(),
+                    shell=get_pane_shell(),
+                    target=p.id
                 )
 
             assert isinstance(p, Pane)


### PR DESCRIPTION
This is supposed to fix #139.

I added a shell-configuration to the pane layer. This way you can specify for every pane what shell/application is supposed to be started. I added an example to the documentation to drive the point home why it makes sense.

I wasn't really able to understand how to add the test cases to the test environment. I hope someone can help with this. The example should hopefully already contain most edge cases in any case.

The more complicated part was to make sure that the shell command for the first pane gets respected by the window creation, as the shell for the first pane has to be handed over to the create-window-command.