### PR TITLE
Fix #649

### DIFF
--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -1071,7 +1071,7 @@ def command_load(
         'tmux_config_file': tmux_config_file,
         'new_session_name': new_session_name,
         'answer_yes': answer_yes,
-        'colors': colors,
+        'colors': int(colors),
         'detached': detached,
         'append': append,
     }


### PR DESCRIPTION
Fixes #649.

It appears click 8 decided to change `flag_value`s to strings - somewhat
reasonably. This commit is backward compatible with click 7, so I'll
leave the dependency alone til a more through evaluation can be
conducted.