### PR TITLE
Allow specifying file name and format as cmd args for freeze, deduce format from filename

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,16 @@
 
 #### What's new
 
+- #701: `tmuxp freeze` now accepts `--quiet` and `--yes` along with the
+  `--config-format` and filename (`--save-to`). This means you can do it all in
+  one command:
+
+  `tmuxp freeze -yqo .tmuxp.yaml`
+
+  Or bind it to `.tmux.conf` itself: `bind -T root C-s run-shell "tmuxp freeze -yqo .tmuxp.yaml"`
+
+  Credit: [@davidatbu](https://github.com/davidatbu)
+
 - #672: Panes now accept `shell` for their initial command.
 
   Equivalent to `tmux split-windows`'s `[shell-command]`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -868,16 +868,16 @@ def test_import_tmuxinator(cli_args, inputs, tmpdir, monkeypatch):
 @pytest.mark.parametrize(
     "cli_args,inputs",
     [
-        (['freeze', 'myfrozensession'], ['\n', 'y\n', './la.yaml\n', 'y\n']),
+        (['freeze', 'myfrozensession'], ['y\n', './la.yaml\n', 'y\n']),
         (  # Exists
             ['freeze', 'myfrozensession'],
-            ['\n', 'y\n', './exists.yaml\n', './la.yaml\n', 'y\n'],
+            ['y\n', './exists.yaml\n', './la.yaml\n', 'y\n'],
         ),
         (  # Imply current session if not entered
             ['freeze'],
-            ['\n', 'y\n', './la.yaml\n', 'y\n'],
+            ['y\n', './la.yaml\n', 'y\n'],
         ),
-        (['freeze'], ['\n', 'y\n', './exists.yaml\n', './la.yaml\n', 'y\n']),  # Exists
+        (['freeze'], ['y\n', './exists.yaml\n', './la.yaml\n', 'y\n']),  # Exists
     ],
 )
 def test_freeze(server, cli_args, inputs, tmpdir, monkeypatch):

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -926,9 +926,17 @@ def command_shell(
     default=False,
     help="Don't prompt for confirmation",
 )
+@click.option(
+    '-q',
+    '--quiet',
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Don't prompt for confirmation",
+)
 @click.option('--force', 'force', help='overwrite the config file', is_flag=True)
 def command_freeze(
-    session_name, socket_name, config_format, save_to, socket_path, yes, force
+    session_name, socket_name, config_format, save_to, socket_path, yes, quiet, force
 ):
     """Snapshot a session into a config.
 
@@ -954,22 +962,24 @@ def command_freeze(
     newconfig = config.inline(sconf)
     configparser.import_config(newconfig)
 
-    print(
-        '---------------------------------------------------------------'
-        '\n'
-        'Freeze does its best to snapshot live tmux sessions.\n'
-    )
+    if not quiet:
+        print(
+            '---------------------------------------------------------------'
+            '\n'
+            'Freeze does its best to snapshot live tmux sessions.\n'
+        )
     if not (
         yes
         or click.confirm(
             'The new config *WILL* require adjusting afterwards. Save config?'
         )
     ):
-        print(
-            'tmuxp has examples in JSON and YAML format at '
-            '<http://tmuxp.git-pull.com/examples.html>\n'
-            'View tmuxp docs at <http://tmuxp.git-pull.com/>.'
-        )
+        if not quiet:
+            print(
+                'tmuxp has examples in JSON and YAML format at '
+                '<http://tmuxp.git-pull.com/examples.html>\n'
+                'View tmuxp docs at <http://tmuxp.git-pull.com/>.'
+            )
         sys.exit()
 
     dest = save_to
@@ -1017,16 +1027,8 @@ def command_freeze(
         buf.write(newconfig)
         buf.close()
 
-        print('Saved to %s.' % dest)
-
-    if config_format == 'yaml':
-        newconfig = configparser.export(
-            'yaml', indent=2, default_flow_style=False, safe=True
-        )
-    elif config_format == 'json':
-        newconfig = configparser.export('json', indent=2)
-    else:
-        sys.exit('Unknown config format.')
+        if not quiet:
+            print('Saved to %s.' % dest)
 
 
 @cli.command(name='load', short_help='Load tmuxp workspaces.')

--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -911,8 +911,25 @@ def command_shell(
 @click.argument('session_name', nargs=1, required=False)
 @click.option('-S', 'socket_path', help='pass-through for tmux -S')
 @click.option('-L', 'socket_name', help='pass-through for tmux -L')
+@click.option(
+    '-f',
+    '--config-format',
+    type=click.Choice(['yaml', 'json']),
+    help='format to save in',
+)
+@click.option('-o', '--save-to', type=click.Path(exists=False), help='file to save to')
+@click.option(
+    '-y',
+    '--yes',
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Don't prompt for confirmation",
+)
 @click.option('--force', 'force', help='overwrite the config file', is_flag=True)
-def command_freeze(session_name, socket_name, socket_path, force):
+def command_freeze(
+    session_name, socket_name, config_format, save_to, socket_path, yes, force
+):
     """Snapshot a session into a config.
 
     If SESSION_NAME is provided, snapshot that session. Otherwise, use the
@@ -936,9 +953,71 @@ def command_freeze(session_name, socket_name, socket_path, force):
     configparser = kaptan.Kaptan()
     newconfig = config.inline(sconf)
     configparser.import_config(newconfig)
-    config_format = click.prompt(
-        'Convert to', value_proc=_validate_choices(['yaml', 'json']), default='yaml'
+
+    print(
+        '---------------------------------------------------------------'
+        '\n'
+        'Freeze does its best to snapshot live tmux sessions.\n'
     )
+    if not (
+        yes
+        or click.confirm(
+            'The new config *WILL* require adjusting afterwards. Save config?'
+        )
+    ):
+        print(
+            'tmuxp has examples in JSON and YAML format at '
+            '<http://tmuxp.git-pull.com/examples.html>\n'
+            'View tmuxp docs at <http://tmuxp.git-pull.com/>.'
+        )
+        sys.exit()
+
+    dest = save_to
+    while not dest:
+        save_to = os.path.abspath(
+            os.path.join(
+                get_config_dir(),
+                '%s.%s' % (sconf.get('session_name'), config_format or 'yaml'),
+            )
+        )
+        dest_prompt = click.prompt(
+            'Save to: %s' % save_to, value_proc=get_abs_path, default=save_to
+        )
+        if not force and os.path.exists(dest_prompt):
+            print('%s exists. Pick a new filename.' % dest_prompt)
+            continue
+
+        dest = dest_prompt
+    dest = os.path.abspath(os.path.relpath(os.path.expanduser(dest)))
+
+    if config_format is None:
+        valid_config_formats = ['json', 'yaml']
+        _, config_format = os.path.splitext(dest)
+        config_format = config_format[1:].lower()
+        if config_format not in valid_config_formats:
+            config_format = click.prompt(
+                "Couldn't ascertain one of [%s] from file name. Convert to"
+                % ", ".join(valid_config_formats),
+                value_proc=_validate_choices(['yaml', 'json']),
+                default='yaml',
+            )
+
+    if config_format == 'yaml':
+        newconfig = configparser.export(
+            'yaml', indent=2, default_flow_style=False, safe=True
+        )
+    elif config_format == 'json':
+        newconfig = configparser.export('json', indent=2)
+
+    if yes or click.confirm('Save to %s?' % dest):
+        destdir = os.path.dirname(dest)
+        if not os.path.isdir(destdir):
+            os.makedirs(destdir)
+        buf = open(dest, 'w')
+        buf.write(newconfig)
+        buf.close()
+
+        print('Saved to %s.' % dest)
 
     if config_format == 'yaml':
         newconfig = configparser.export(
@@ -948,49 +1027,6 @@ def command_freeze(session_name, socket_name, socket_path, force):
         newconfig = configparser.export('json', indent=2)
     else:
         sys.exit('Unknown config format.')
-
-    print(
-        '---------------------------------------------------------------'
-        '\n'
-        'Freeze does its best to snapshot live tmux sessions.\n'
-    )
-    if click.confirm(
-        'The new config *WILL* require adjusting afterwards. Save config?'
-    ):
-        dest = None
-        while not dest:
-            save_to = os.path.abspath(
-                os.path.join(
-                    get_config_dir(),
-                    '%s.%s' % (sconf.get('session_name'), config_format),
-                )
-            )
-            dest_prompt = click.prompt(
-                'Path to new config:', value_proc=get_abs_path, default=save_to
-            )
-            if not force and os.path.exists(dest_prompt):
-                print('%s exists. Pick a new filename.' % dest_prompt)
-                continue
-
-            dest = dest_prompt
-
-        dest = os.path.abspath(os.path.relpath(os.path.expanduser(dest)))
-        if click.confirm('Save to %s?' % dest):
-            destdir = os.path.dirname(dest)
-            if not os.path.isdir(destdir):
-                os.makedirs(destdir)
-            buf = open(dest, 'w')
-            buf.write(newconfig)
-            buf.close()
-
-            print('Saved to %s.' % dest)
-    else:
-        print(
-            'tmuxp has examples in JSON and YAML format at '
-            '<http://tmuxp.git-pull.com/examples.html>\n'
-            'View tmuxp docs at <http://tmuxp.git-pull.com/>.'
-        )
-        sys.exit()
 
 
 @cli.command(name='load', short_help='Load tmuxp workspaces.')


### PR DESCRIPTION
First off, thanks for this Python solution to tmux session management! Works quite well.

`tmuxp freeze` does a lot of prompting, but I wanted the option to not be prompted sometimes (for example, I want to setup a binding in tmux that saves the current session in the current directory, and I don't want to be prompted for file name / file format).

So this commit adds the following:

1. The `-o` / `--save-to` option. If the user doesn't provide it, we will prompt.
2. The `-f` / `--config-format` option. If the user doesn't provide it, we'll try to deduce it from the extension of the file specified by the `--save-to` option. If that doesn't give a valid format, we prompt the user.
3. The `-y` / `--yes` option. In addition to the prompts for the above two, we currently prompt for cofnrimation/warning two additional times when doing `freeze`. Specifying this `-y` flag avoids that.
4. The `-q` / `--quiet` option reduces some informative output. This is mostly a personal preference. I like my command line tools to be as quiet as possible.

I haven't touched the tests here. I wanted to confirm that there was interest from the maintainers first.

A good demonstration of what the above changes enable is the following tmux mapping:
```tmux
bind -T root C-s run-shell "tmuxp freeze -yqo .tmuxp.yaml"
```
This silently saves the current session in the current working directory of tmux after pressing Ctrl-S.
