### PR TITLE
Fix `distutils.version.Version` deprecation warning (python 3.10)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ $ pipx install --suffix=@next 'tmuxp' --pip-args '\--pre' --force
 
 ## tmuxp 1.19.x (unreleased)
 
+<!-- Maintainers, insert changes / features for the next release here -->
+
 ### What's new
 
 - Environment variables for windows / panes (#845)
@@ -48,7 +50,14 @@ $ pipx install --suffix=@next 'tmuxp' --pip-args '\--pre' --force
 
   Credit: @zappolowski
 
-<!-- Maintainers, insert changes / features for the next release here -->
+### Internal
+
+- Update libtmux 0.15.9 -> 0.16.0
+
+  - Support for environmental variables
+  - Remove reliance on `distutils.version.LooseVersion` for
+    `libtmux._compat.LegacyVersion`
+- Fix distutil warnings by using libtmux 0.16.0's `LegacyVersion` (#727)
 
 ## tmuxp 1.18.2 (2022-11-06)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,9 +18,7 @@ line_length = 88
 
 [tool:pytest]
 filterwarnings = 
-	ignore:distutils Version classes are deprecated. Use packaging.version instead.
 	ignore:The frontend.Option(Parser)? class.*:DeprecationWarning::
-
 addopts = --reruns=0 --tb=short --no-header --showlocals --doctest-modules
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
 testpaths =

--- a/src/tmuxp/plugin.py
+++ b/src/tmuxp/plugin.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import libtmux
 from libtmux.common import get_version
@@ -84,7 +84,7 @@ class TmuxpPlugin:
         # Dependency versions
         self.tmux_version = get_version()
         self.libtmux_version = libtmux.__version__
-        self.tmuxp_version = LooseVersion(__version__)
+        self.tmuxp_version = Version(__version__)
 
         self.version_constraints = {
             "tmux": {
@@ -135,9 +135,9 @@ class TmuxpPlugin:
         """
         Provide affirmative if version compatibility is correct.
         """
-        if vmin and version < LooseVersion(vmin):
+        if vmin and version < Version(vmin):
             return False
-        if vmax and version > LooseVersion(vmax):
+        if vmax and version > Version(vmax):
             return False
         if version in incompatible:
             return False

--- a/src/tmuxp/plugin.py
+++ b/src/tmuxp/plugin.py
@@ -1,6 +1,5 @@
-from packaging.version import Version
-
 import libtmux
+from libtmux._compat import LegacyVersion as Version
 from libtmux.common import get_version
 
 from .__about__ import __version__


### PR DESCRIPTION
Fix #768

See also: https://github.com/tmux-python/libtmux/pull/351