### PR TITLE
feat: Allow passing `sleep` to commands

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,18 @@
 
 #### What's new
 
+- #749: Sleep before command execution, via `sleep: false` (per-pane only)
+
+  ```yaml
+  session_name: Should not execute
+  windows:
+  - panes:
+    - shell_command: echo "___$((1 + 3))___"
+      sleep: 2
+  ```
+
+  This will pause 2 seconds before execution
+
 - #747: Skip execution via `enter: false`
 
   ```yaml

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -356,6 +356,33 @@ Omit sending {kbd}`enter` to key commands. Equivalent to
 
 ````
 
+## Pause / delay command execution
+
+```{versionadded} 1.10.0bX
+`sleep: [seconds]` option
+```
+
+Omit sending {kbd}`enter` to key commands. Equivalent to
+[`time.sleep()`](time.sleep) before [`send_keys(enter=False)`](libtmux.Pane.send_keys).
+
+````{tab} YAML
+
+```{literalinclude} ../examples/sleep.yaml
+:language: yaml
+
+```
+
+````
+
+````{tab} JSON
+
+```{literalinclude} ../examples/sleep.json
+:language: json
+
+```
+
+````
+
 ## Window Index
 
 You can specify a window's index using the `window_index` property. Windows

--- a/examples/sleep.json
+++ b/examples/sleep.json
@@ -1,0 +1,13 @@
+{
+  "session_name": "Should sleep 3 seconds before sending pane commands",
+  "windows": [
+    {
+      "panes": [
+        {
+          "shell_command": "echo \"___$((1 + 3))___\"",
+          "sleep": 3
+        }
+      ]
+    }
+  ]
+}

--- a/examples/sleep.yaml
+++ b/examples/sleep.yaml
@@ -1,0 +1,5 @@
+session_name: Should sleep 3 seconds before sending pane commands
+windows:
+- panes:
+  - shell_command: echo "___$((1 + 3))___"
+    sleep: 3

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -5,6 +5,7 @@ tmuxp.workspacebuilder
 
 """
 import logging
+import time
 
 from libtmux.exc import TmuxSessionExists
 from libtmux.pane import Pane
@@ -363,8 +364,14 @@ class WorkspaceBuilder:
                 suppress = True
 
             enter = pconf.get("enter", True)
+            sleep = pconf.get("sleep", None)
+
             for cmd in pconf["shell_command"]:
                 enter = cmd.get("enter", enter)
+                sleep = cmd.get("sleep", sleep)
+
+                if sleep is not None:
+                    time.sleep(sleep)
 
                 p.send_keys(cmd["cmd"], suppress_history=suppress, enter=enter)
 


### PR DESCRIPTION
addressed by #750

~Blocked by #751~

#748 

commands:

```
session_name: 'sleep command'
windows:
- panes:
    - shell_command: echo "___$((1 + 3))___"
      sleep: 3
```