### PR TITLE
Command level `enter: false`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,7 +12,13 @@
   session_name: Should not execute
   windows:
     - panes:
-        - shell_command: echo "___$((1 + 3))___"
+        - shell_command:
+	  - cmd: echo "___$((1 + 3))___"
+            enter: false
+
+	# pane-wide skip
+        - shell_command:
+	  - echo "___$((1 + 3))___"
           enter: false
   ```
 

--- a/CHANGES
+++ b/CHANGES
@@ -77,7 +77,7 @@
 
 - #752: Command structure (internal API)
 
-  To pave the way for per-command options such as `enter: false` (#52), commands are now a different format:
+  To pave the way for per-command options such as `enter: false` (#53), commands are now a different format:
 
   Before, [`str`](str):
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -331,8 +331,9 @@ This will add the `shell_command` to the bash history in the pane.
 ## Skip command execution
 
 ```{versionadded} 1.10.0b1
-`enter: false` option. This is only available at the pane (not command level)
-until [#751](https://github.com/tmux-python/tmuxp/issues/751) is published.
+`enter: false` option. Pane-level support.
+```{versionadded} 1.10.0b3
+Support command-level skipping.
 ```
 
 Omit sending {kbd}`enter` to key commands. Equivalent to
@@ -355,6 +356,25 @@ Omit sending {kbd}`enter` to key commands. Equivalent to
 ```
 
 ````
+
+````{tab} YAML (pane-level)
+
+```{literalinclude} ../examples/skip-send-pane-level.yaml
+:language: yaml
+
+```
+
+````
+
+````{tab} JSON (pane-level)
+
+```{literalinclude} ../examples/skip-send-pane-level.json
+:language: json
+
+```
+
+````
+
 
 ## Window Index
 

--- a/examples/skip-send-pane-level.json
+++ b/examples/skip-send-pane-level.json
@@ -1,0 +1,20 @@
+{
+  "session_name": "Skip all pane commands",
+  "windows": [
+    {
+      "panes": [
+        {
+          "shell_command": "echo \"___$((1 + 3))___\"",
+          "enter": false
+        },
+        {
+          "shell_command": [
+            "echo \"___$((1 + 3))___\"\\;",
+            "echo \"___$((1 + 3))___\""
+          ],
+          "enter": false
+        }
+      ]
+    }
+  ]
+}

--- a/examples/skip-send-pane-level.yaml
+++ b/examples/skip-send-pane-level.yaml
@@ -1,0 +1,9 @@
+session_name: Skip all pane commands
+windows:
+- panes:
+  - shell_command: echo "___$((1 + 3))___"
+    enter: false
+  - shell_command:
+    - echo "___$((1 + 3))___"\;
+    - echo "___$((1 + 3))___"
+    enter: false

--- a/examples/skip-send.json
+++ b/examples/skip-send.json
@@ -1,11 +1,16 @@
 {
-  "session_name": "Should not execute",
+  "session_name": "Skip command execution (command-level)",
   "windows": [
     {
       "panes": [
         {
-          "shell_command": "echo \"___$((1 + 3))___\"",
-          "enter": false
+          "shell_command": [
+            "echo \"___$((11 + 1))___\"",
+            {
+              "cmd": "echo \"___$((1 + 3))___\"",
+              "enter": false
+            }
+          ]
         }
       ]
     }

--- a/examples/skip-send.yaml
+++ b/examples/skip-send.yaml
@@ -1,5 +1,9 @@
-session_name: Should not execute
+session_name: Skip command execution (command-level)
 windows:
 - panes:
-  - shell_command: echo "___$((1 + 3))___"
-    enter: false
+  - shell_command:
+    # You can see this
+    - echo "___$((11 + 1))___"
+    # This is skipped
+    - cmd: echo "___$((1 + 3))___"
+      enter: false

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -924,12 +924,70 @@ windows:
             "___4___",
             True,
         ],
+        [
+            textwrap.dedent(
+                """
+session_name: Should not execute
+windows:
+- panes:
+  - shell_command:
+    - cmd: echo "___$((1 + 3))___"
+      enter: false
+    """
+            ),
+            "___4___",
+            False,
+        ],
+        [
+            textwrap.dedent(
+                """
+session_name: Should not execute
+windows:
+- panes:
+  - shell_command:
+    - cmd: echo "___$((1 + 3))___"
+      enter: false
+    """
+            ),
+            "___4___",
+            False,
+        ],
+        [
+            textwrap.dedent(
+                """
+session_name: Should execute
+windows:
+- panes:
+  - shell_command: echo "___$((1 + 3))___"
+  """
+            ),
+            "___4___",
+            True,
+        ],
+        [
+            textwrap.dedent(
+                """
+session_name: Should execute
+windows:
+- panes:
+  - shell_command:
+    - cmd: echo "other command"
+    - cmd: echo "___$((1 + 3))___"
+  """
+            ),
+            "___4___",
+            True,
+        ],
     ],
     ids=[
         "pane_enter_false_shortform",
         "pane_enter_false_longform",
         "pane_enter_default_shortform",
         "pane_enter_default_longform",
+        "pane_command_enter_false_shortform",
+        "pane_command_enter_false_longform",
+        "pane_command_enter_default_shortform",
+        "pane_command_enter_default_longform",
     ],
 )
 def test_load_workspace_enter(

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -363,8 +363,9 @@ class WorkspaceBuilder:
                 suppress = True
 
             enter = pconf.get("enter", True)
-
             for cmd in pconf["shell_command"]:
+                enter = cmd.get("enter", enter)
+
                 p.send_keys(cmd["cmd"], suppress_history=suppress, enter=enter)
 
             if "focus" in pconf and pconf["focus"]:


### PR DESCRIPTION
re: #53 #293 #735

```yaml
session_name: Skip command execution (command-level)
windows:
- panes:
  - shell_command:
    # You can see this
    - echo "___$((11 + 1))___"
    # This is skipped
    - cmd: echo "___$((1 + 3))___"
      enter: false
```