### PR TITLE
use /etc instead of /usr/sbin which could be a symlink

### DIFF
--- a/tests/fixtures/workspacebuilder/pane_ordering.yaml
+++ b/tests/fixtures/workspacebuilder/pane_ordering.yaml
@@ -7,5 +7,5 @@ windows:
   panes:
   - cd /usr/bin
   - cd /usr
-  - cd /usr/sbin
+  - cd /etc
   - cd {HOME}

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -525,7 +525,7 @@ def test_pane_order(session):
     pane_paths = [
         "/usr/bin",
         "/usr",
-        "/usr/sbin",
+        "/etc",
         os.path.realpath(os.path.expanduser("~")),
     ]
 
@@ -539,10 +539,10 @@ def test_pane_order(session):
 
     window_count = len(session._windows)  # current window count
     assert len(s._windows) == window_count
+
     for w, wconf in builder.iter_create_windows(s):
         for p in builder.iter_create_panes(w, wconf):
             w.select_layout("tiled")  # fix glitch with pane size
-            p = p
             assert len(s._windows) == window_count
 
         assert isinstance(w, Window)
@@ -563,9 +563,7 @@ def test_pane_order(session):
                 p.server._update_panes()
                 return p.current_path == pane_path
 
-            retry_until(f)
-
-            assert p.current_path, pane_path
+            assert retry_until(f)
 
 
 def test_window_index(session):


### PR DESCRIPTION
fixes #620 for good (until someone has a computer in which any of `/usr/bin`, `/usr` or `/etc` is a symbolic link.