### PR TITLE
`tmuxp load` tab completions: Fix tilde

### DIFF
--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -14,6 +14,7 @@ from typing import List
 
 import click
 import kaptan
+from click.shell_completion import CompletionItem
 
 from libtmux.common import has_gte_version
 from libtmux.server import Server
@@ -441,7 +442,9 @@ def load_workspace(
     return _setup_plugins(builder)
 
 
-def config_file_completion(ctx, params, incomplete):
+def config_file_completion(
+    ctx: click.Context, param: click.Parameter, incomplete: str
+) -> List[CompletionItem]:
     config_dir = pathlib.Path(get_config_dir())
     choices: List[pathlib.Path] = []
 

--- a/src/tmuxp/cli/utils.py
+++ b/src/tmuxp/cli/utils.py
@@ -111,7 +111,12 @@ class ConfigPath(click.Path):
         )
         self.config_dir = config_dir
 
-    def convert(self, value, param, ctx):
+    def convert(
+        self,
+        value: t.Any,
+        param: t.Optional[click.Parameter],
+        ctx: t.Optional[click.Context],
+    ) -> t.Any:
         config_dir = self.config_dir
         if callable(config_dir):
             config_dir = config_dir()

--- a/src/tmuxp/cli/utils.py
+++ b/src/tmuxp/cli/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import typing as t
 
 import click
 from click.exceptions import FileError
@@ -84,8 +85,30 @@ def _validate_choices(options):
 
 
 class ConfigPath(click.Path):
-    def __init__(self, config_dir=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        config_dir=None,
+        exists: bool = False,
+        file_okay: bool = True,
+        dir_okay: bool = True,
+        writable: bool = False,
+        readable: bool = True,
+        resolve_path: bool = False,
+        allow_dash: bool = False,
+        path_type: t.Optional[t.Type] = None,
+        executable: bool = False,
+    ):
+        super().__init__(
+            exists=exists,
+            file_okay=file_okay,
+            dir_okay=dir_okay,
+            writable=writable,
+            readable=readable,
+            resolve_path=resolve_path,
+            allow_dash=allow_dash,
+            path_type=path_type,
+            executable=executable,
+        )
         self.config_dir = config_dir
 
     def convert(self, value, param, ctx):


### PR DESCRIPTION
- Adds typings for `ConfigPath`
  - constructor
  - config