### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,7 +29,7 @@ $ brew install tmuxp
 ### Developmental releases
 
 New versions of tmuxp are published to PyPI as alpha, beta, or release candidates.
-In their versions you will see notfication like `a1`, `b1`, and `rc1`, respectively.
+In their versions you will see notification like `a1`, `b1`, and `rc1`, respectively.
 `1.10.0b4` would mean the 4th beta release of `1.10.0` before general availability.
 
 - [pip]\:

--- a/tmuxp/cli/shell.py
+++ b/tmuxp/cli/shell.py
@@ -57,7 +57,7 @@ def command_shell(
 ):
     """Launch python shell for tmux server, session, window and pane.
 
-    Priority given to loaded session/wndow/pane objects:
+    Priority given to loaded session/window/pane objects:
 
     - session_name and window_name arguments
     - current shell: envvar ``TMUX_PANE`` for determining window and session


### PR DESCRIPTION
There are small typos in:
- docs/quickstart.md
- tmuxp/cli/shell.py

Fixes:
- Should read `window` rather than `wndow`.
- Should read `notification` rather than `notfication`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md