### PR TITLE
Fix `start_directory` not being respected in first pane

### DIFF
--- a/tests/fixtures/workspacebuilder/first_pane_start_directory.yaml
+++ b/tests/fixtures/workspacebuilder/first_pane_start_directory.yaml
@@ -1,0 +1,5 @@
+session_name: sampleconfig
+windows:
+  - panes:
+    - start_directory: /usr
+    - start_directory: /etc

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -261,6 +261,11 @@ class WorkspaceBuilder:
             else:
                 sd = None
 
+            # If the first pane specifies a start_directory, use that instead.
+            panes = wconf["panes"]
+            if panes and "start_directory" in panes[0]:
+                sd = panes[0]["start_directory"]
+
             if "window_shell" in wconf:
                 ws = wconf["window_shell"]
             else:


### PR DESCRIPTION
Respect start_directory for first pane.