### PR TITLE
libtmux v0.15

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -287,7 +287,7 @@ PyYAML = ">=3.13,<6"
 
 [[package]]
 name = "libtmux"
-version = "0.14.2"
+version = "0.15.0"
 description = "Typed scripting library / ORM / API wrapper for tmux"
 category = "main"
 optional = false
@@ -966,7 +966,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0d3fa296490ee32bf47fd88574a245a11910f959fdd64fe2c6519b247b127b83"
+content-hash = "4964d7494c27a54beb1312e28c7527e5cb112fe0a2255f20d11fd9e8cbb31b43"
 
 [metadata.files]
 aafigure = [
@@ -1135,8 +1135,8 @@ kaptan = [
     {file = "kaptan-0.5.12.tar.gz", hash = "sha256:1abd1f56731422fce5af1acc28801677a51e56f5d3c3e8636db761ed143c3dd2"},
 ]
 libtmux = [
-    {file = "libtmux-0.14.2-py3-none-any.whl", hash = "sha256:f5fafadb91d2c9f3f9eba57eadc4b51daaac308cfcfc4c5c44afdb41ef8e7995"},
-    {file = "libtmux-0.14.2.tar.gz", hash = "sha256:38ee348a119c4f60caa9cefc66f15c5d0d46b8cabb3e59dcf22162f8773f8a48"},
+    {file = "libtmux-0.15.0-py3-none-any.whl", hash = "sha256:2f53d97ebfd2f4ddc703dc8b187749c6dd76fa00c7070b53f81fdabf49163ce5"},
+    {file = "libtmux-0.15.0.tar.gz", hash = "sha256:77a9e88d7a9e348746feddda1bf41d70aec6ebf309d2a639cdd000f48f6a159e"},
 ]
 livereload = [
     {file = "livereload-2.6.3.tar.gz", hash = "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"},
@@ -1251,8 +1251,8 @@ pillow = [
     {file = "Pillow-9.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:37ff6b522a26d0538b753f0b4e8e164fdada12db6c6f00f62145d732d8a3152e"},
     {file = "Pillow-9.2.0-cp310-cp310-win32.whl", hash = "sha256:c79698d4cd9318d9481d89a77e2d3fcaeff5486be641e60a4b49f3d2ecca4e28"},
     {file = "Pillow-9.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:254164c57bab4b459f14c64e93df11eff5ded575192c294a0c49270f22c5d93d"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:adabc0bce035467fb537ef3e5e74f2847c8af217ee0be0455d4fec8adc0462fc"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:336b9036127eab855beec9662ac3ea13a4544a523ae273cbf108b228ecac8437"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:408673ed75594933714482501fe97e055a42996087eeca7e5d06e33218d05aa8"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:727dd1389bc5cb9827cbd1f9d40d2c2a1a0c9b32dd2261db522d22a604a6eec9"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50dff9cc21826d2977ef2d2a205504034e3a4563ca6f5db739b0d1026658e004"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb6259196a589123d755380b65127ddc60f4c64b21fc3bb46ce3a6ea663659b0"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b0554af24df2bf96618dac71ddada02420f946be943b181108cac55a7a2dcd4"},
@@ -1352,7 +1352,37 @@ pytz = [
     {file = "pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
     {file = "pytz-2022.2.1.tar.gz", hash = "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"},
 ]
-pyyaml = []
+pyyaml = [
+    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
+    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
+    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
+    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
+    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ tmuxp = 'tmuxp:cli.cli'
 python = "^3.7"
 click = "~8"
 kaptan = ">=0.5.10"
-libtmux = "~0.14.0"
+libtmux = "~0.15.0"
 colorama = ">=0.3.9"
 
 [tool.poetry.dev-dependencies]

--- a/tmuxp/cli/debug_info.py
+++ b/tmuxp/cli/debug_info.py
@@ -1,12 +1,13 @@
 import os
 import pathlib
 import platform
+import shutil
 import sys
 
 import click
 
 from libtmux import __version__ as libtmux_version
-from libtmux.common import get_version, tmux_cmd, which
+from libtmux.common import get_version, tmux_cmd
 
 from ..__about__ import __version__
 from .utils import tmuxp_echo
@@ -62,7 +63,7 @@ def command_debug_info():
         "tmux version: %s" % get_version(),
         "libtmux version: %s" % libtmux_version,
         "tmuxp version: %s" % __version__,
-        "tmux path: %s" % which("tmux"),
+        "tmux path: %s" % shutil.which("tmux"),
         "tmuxp path: %s" % tmuxp_path,
         "shell: %s" % os.environ["SHELL"],
         output_break(),

--- a/tmuxp/cli/load.py
+++ b/tmuxp/cli/load.py
@@ -8,13 +8,14 @@ import importlib
 import logging
 import os
 import pathlib
+import shutil
 import sys
 from typing import List
 
 import click
 import kaptan
 
-from libtmux.common import has_gte_version, which
+from libtmux.common import has_gte_version
 from libtmux.server import Server
 
 from .. import config, exc, log, util
@@ -357,7 +358,7 @@ def load_workspace(
         colors=colors,
     )
 
-    which("tmux")  # raise exception if tmux not found
+    shutil.which("tmux")  # raise exception if tmux not found
 
     try:  # load WorkspaceBuilder object for tmuxp config / tmux server
         builder = WorkspaceBuilder(

--- a/tmuxp/conftest.py
+++ b/tmuxp/conftest.py
@@ -2,6 +2,7 @@ import getpass
 import logging
 import os
 import pathlib
+import shutil
 import typing as t
 
 import pytest
@@ -10,7 +11,6 @@ from _pytest.doctest import DoctestItem
 from _pytest.fixtures import SubRequest
 
 from libtmux import exc
-from libtmux.common import which
 from libtmux.server import Server
 from libtmux.test import TEST_SESSION_PREFIX, get_test_session_name, namer
 from tests.fixtures import utils as test_utils
@@ -140,7 +140,7 @@ def add_doctest_fixtures(
     request: SubRequest,
     doctest_namespace: t.Dict[str, t.Any],
 ) -> None:
-    if isinstance(request._pyfuncitem, DoctestItem) and which("tmux"):
+    if isinstance(request._pyfuncitem, DoctestItem) and shutil.which("tmux"):
         doctest_namespace["server"] = request.getfixturevalue("server")
         session: "Session" = request.getfixturevalue("session")
         doctest_namespace["session"] = session

--- a/tmuxp/conftest.py
+++ b/tmuxp/conftest.py
@@ -1,4 +1,3 @@
-import getpass
 import logging
 import os
 import pathlib
@@ -22,18 +21,6 @@ logger = logging.getLogger(__name__)
 USING_ZSH = "zsh" in os.getenv("SHELL", "")
 
 
-@pytest.fixture(autouse=True, scope="session")
-def home_path(tmp_path_factory: pytest.TempPathFactory):
-    return tmp_path_factory.mktemp("home")
-
-
-@pytest.fixture(autouse=True, scope="session")
-def user_path(home_path: pathlib.Path):
-    p = home_path / getpass.getuser()
-    p.mkdir()
-    return p
-
-
 @pytest.mark.skipif(USING_ZSH, reason="Using ZSH")
 @pytest.fixture(autouse=USING_ZSH, scope="session")
 def zshrc(user_path: pathlib.Path):
@@ -47,8 +34,8 @@ def zshrc(user_path: pathlib.Path):
 
 
 @pytest.fixture(autouse=True)
-def home_path_default(user_path: pathlib.Path):
-    os.environ["HOME"] = str(user_path)
+def home_path_default(monkeypatch: pytest.MonkeyPatch, user_path: pathlib.Path) -> None:
+    monkeypatch.setenv("HOME", str(user_path))
 
 
 @pytest.fixture(scope="function")

--- a/tmuxp/conftest.py
+++ b/tmuxp/conftest.py
@@ -7,11 +7,8 @@ import typing as t
 import pytest
 
 from _pytest.doctest import DoctestItem
-from _pytest.fixtures import SubRequest
 
-from libtmux import exc
-from libtmux.server import Server
-from libtmux.test import TEST_SESSION_PREFIX, get_test_session_name, namer
+from libtmux.test import namer
 from tests.fixtures import utils as test_utils
 
 if t.TYPE_CHECKING:
@@ -57,74 +54,9 @@ def socket_name(request) -> str:
     return "tmuxp_test%s" % next(namer)
 
 
-@pytest.fixture(scope="function")
-def server(
-    request: SubRequest, monkeypatch: pytest.MonkeyPatch, socket_name: str
-) -> Server:
-    tmux = Server(socket_name=socket_name)
-
-    def fin() -> None:
-        tmux.kill_server()
-
-    request.addfinalizer(fin)
-
-    return tmux
-
-
-@pytest.fixture(scope="function")
-def session(server):
-    session_name = "tmuxp"
-
-    if not server.has_session(session_name):
-        server.cmd(
-            "-f",
-            "/dev/null",  # use a blank config to reduce side effects
-            "new-session",
-            "-d",  # detached
-            "-s",
-            session_name,
-            "/bin/sh",  # use /bin/sh as a shell to reduce side effects
-            # normally, it'd be -c, but new-session is special
-        )
-
-    # find current sessions prefixed with tmuxp
-    old_test_sessions = [
-        s.get("session_name")
-        for s in server._sessions
-        if s.get("session_name").startswith(TEST_SESSION_PREFIX)
-    ]
-
-    TEST_SESSION_NAME = get_test_session_name(server=server)
-
-    try:
-        session = server.new_session(session_name=TEST_SESSION_NAME)
-    except exc.LibTmuxException as e:
-        raise e
-
-    """
-    Make sure that tmuxp can :ref:`test_builder_visually` and switches to
-    the newly created session for that testcase.
-    """
-    session_id = session.get("session_id")
-    assert session_id is not None
-    try:
-        server.switch_client(target_session=session_id)
-    except exc.LibTmuxException:
-        # server.attach_session(session.get('session_id'))
-        pass
-
-    for old_test_session in old_test_sessions:
-        logger.debug("Old test test session %s found. Killing it." % old_test_session)
-        server.kill_session(old_test_session)
-    assert TEST_SESSION_NAME == session.get("session_name")
-    assert TEST_SESSION_NAME != "tmuxp"
-
-    return session
-
-
 @pytest.fixture(autouse=True)
 def add_doctest_fixtures(
-    request: SubRequest,
+    request: pytest.FixtureRequest,
     doctest_namespace: t.Dict[str, t.Any],
 ) -> None:
     if isinstance(request._pyfuncitem, DoctestItem) and shutil.which("tmux"):


### PR DESCRIPTION
## libtmux v0.15

- libtmux v0.15.0a0's `tmux_cmd` change: https://github.com/tmux-python/libtmux/issues/402
- libtmux v0.15.0a1's deprecation of `which()` in favor of [`shtuil.which()`](https://docs.python.org/3/library/shutil.html#shutil.which), https://github.com/tmux-python/libtmux/pull/407
- libtmux v0.15's later alphas introduced a pytest plugin. We're using that instead of our own fixtures