### PR TITLE
tests / fix: Fix v1.13.1 pane spacing issue

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,34 @@ $ pipx install --suffix=@next 'tmuxp' --pip-args '\--pre' --force
 - Add [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) (#807)
 - Add [flake8-comprehensions](https://github.com/adamchainz/flake8-comprehensions) (#808)
 
+## tmuxp 1.13.x (2022-09-10)
+
+### Bug fixes
+
+- Layout size has been bumped for those experiencing layout spacing issues
+  (#809, fixes #800)
+
+  If you encounter issues with pane spacing, consider passing an `option` like
+  so:
+
+  ```yaml
+  session_name: main-pane-height
+  start_directory: "~"
+  options:
+    default-size: 999x999
+  windows:
+    - window_name: my window name
+      layout: main-horizontal
+      options:
+        main-pane-height: 30
+      panes:
+        - shell_command: top
+        - shell_command: top
+        - shell_command: top
+        - shell_command: echo "hey"
+        - shell_command: echo "moo"
+  ```
+
 ## tmuxp 1.13.1 (2022-08-21)
 
 ### Bug fixes

--- a/tests/fixtures/regressions/issue_800_default_size_many_windows.yaml
+++ b/tests/fixtures/regressions/issue_800_default_size_many_windows.yaml
@@ -1,0 +1,12 @@
+session_name: many-windows-issue
+windows:
+- window_name: moo
+  layout: main-horizontal
+  panes:
+  - echo hello
+  - echo hello
+  - echo hello
+  - echo hello
+  - echo hello
+  - echo hello
+  - echo hello

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -1232,10 +1232,16 @@ class DefaultSizeNamespaceFixture(t.NamedTuple):
 
 DEFAULT_SIZE_FIXTURES = [
     DefaultSizeNamespaceFixture(
+        test_id="default-behavior",
+        TMUXP_DEFAULT_SIZE=None,
+        raises=False,
+        confoverrides={},
+    ),
+    DefaultSizeNamespaceFixture(
         test_id="v1.13.1 default-size-breaks",
         TMUXP_DEFAULT_SIZE=None,
         raises=True,
-        confoverrides={},
+        confoverrides={"options": {"default-size": "80x24"}},
     ),
     DefaultSizeNamespaceFixture(
         test_id="v1.13.1-option-workaround",

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -1213,7 +1213,15 @@ def test_layout_main_horizontal(session):
     def width(p):
         return int(p._info["pane_width"])
 
-    assert height(main_horizontal_pane) > height(panes[0])
+    main_horizontal_pane_height = height(main_horizontal_pane)
+    pane_heights = [height(pane) for pane in panes]
+    # TODO: When libtmux has new pane formatters added, use that to detect top / bottom
+    assert all(
+        main_horizontal_pane_height != pane_height for pane_height in pane_heights
+    ), "The top row should not be the same size as the bottom row (even though it can)"
+    assert all(
+        pane_heights[0] == pane_height for pane_height in pane_heights
+    ), "The bottom row should be uniform height"
     assert width(main_horizontal_pane) > width(panes[0])
 
     def is_almost_equal(x, y):

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -219,7 +219,7 @@ class WorkspaceBuilder:
 
         if has_gte_version("2.9"):
             # Use tmux default session size, overwrite Server::new_session
-            session.set_option("default-size", "80x24")
+            session.set_option("default-size", "800x600")
 
         self.session = session
         self.server = session.server

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -19,6 +19,10 @@ from .util import get_current_pane, run_before_script
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_WIDTH = "800"
+DEFAULT_HEIGHT = "600"
+DEFAULT_SIZE = f"{DEFAULT_WIDTH}x{DEFAULT_HEIGHT}"
+
 
 class WorkspaceBuilder:
 
@@ -219,7 +223,7 @@ class WorkspaceBuilder:
 
         if has_gte_version("2.9"):
             # Use tmux default session size, overwrite Server::new_session
-            session.set_option("default-size", "800x600")
+            session.set_option("default-size", DEFAULT_SIZE)
 
         self.session = session
         self.server = session.server

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -205,15 +205,14 @@ class WorkspaceBuilder:
                     "Session name %s is already running." % self.sconf["session_name"]
                 )
             else:
+                new_session_kwargs = {}
                 if "start_directory" in self.sconf:
-                    session = self.server.new_session(
-                        session_name=self.sconf["session_name"],
-                        start_directory=self.sconf["start_directory"],
-                    )
-                else:
-                    session = self.server.new_session(
-                        session_name=self.sconf["session_name"]
-                    )
+                    new_session_kwargs["start_directory"] = self.sconf[
+                        "start_directory"
+                    ]
+                session = self.server.new_session(
+                    session_name=self.sconf["session_name"]
+                )
 
             assert self.sconf["session_name"] == session.name
             assert len(self.sconf["session_name"]) > 0


### PR DESCRIPTION
re: #800, #806


w/ `entr(1)`:

```console
make watch_test test='tests/test_workspacebuilder.py::test_issue_800_default_size_many_windows -vvv -x -s' 
```

This may negate the fix in #793 (we may not be able to hard-code it)