### PR TITLE
Revert v1.13.1's changes temporarily

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,12 @@ $ pipx install --suffix=@next 'tmuxp' --pip-args '\--pre' --force
 - Add [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) (#807)
 - Add [flake8-comprehensions](https://github.com/adamchainz/flake8-comprehensions) (#808)
 
+## tmuxp 1.13.x (unreleased)
+
+- Revert v1.13.1's #793 change for now, the behavior behind launching workspace
+  layouts need to be understood clearly. Future releases will decisively solve
+  this issue (#811).
+
 ## tmuxp 1.13.2 (2022-09-10)
 
 ### Bug fixes

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -7,7 +7,6 @@ tmuxp.workspacebuilder
 import logging
 import time
 
-from libtmux.common import has_gte_version
 from libtmux.exc import TmuxSessionExists
 from libtmux.pane import Pane
 from libtmux.server import Server
@@ -221,10 +220,6 @@ class WorkspaceBuilder:
             assert self.sconf["session_name"] == session.name
             assert len(self.sconf["session_name"]) > 0
 
-        if has_gte_version("2.9"):
-            # Use tmux default session size, overwrite Server::new_session
-            session.set_option("default-size", DEFAULT_SIZE)
-
         self.session = session
         self.server = session.server
 
@@ -272,6 +267,9 @@ class WorkspaceBuilder:
                 assert isinstance(p, Pane)
                 p = p
 
+                if "layout" in wconf:
+                    w.select_layout(wconf["layout"])
+
                 if "focus" in pconf and pconf["focus"]:
                     focus_pane = p
 
@@ -285,8 +283,6 @@ class WorkspaceBuilder:
 
             if focus_pane:
                 focus_pane.select_pane()
-
-            w.select_layout(wconf.get("layout", "even-vertical"))
 
         if focus:
             focus.select_window()
@@ -428,6 +424,8 @@ class WorkspaceBuilder:
                 )
 
             assert isinstance(p, Pane)
+            if "layout" in wconf:
+                w.select_layout(wconf["layout"])
 
             if "suppress_history" in pconf:
                 suppress = pconf["suppress_history"]


### PR DESCRIPTION
The reason why is I have upcoming changes and refactorings (like #805) that are noops, and we should at least stay with the earlier broken behavior (the broken behavior we know) while we investigate a better way to do v1.13.1. Me and @nvasilas will release an improved solution

> Revert "Fix layout related issues #737, #667, #704"
> 
> This reverts commit fb9a8affd5060dc9173104238a460bbc32ccf059.