### PR TITLE
Pass start_directory to new_session when building a session

### DIFF
--- a/src/tmuxp/workspacebuilder.py
+++ b/src/tmuxp/workspacebuilder.py
@@ -214,7 +214,8 @@ class WorkspaceBuilder:
                         "start_directory"
                     ]
                 session = self.server.new_session(
-                    session_name=self.sconf["session_name"]
+                    session_name=self.sconf["session_name"],
+                    **new_session_kwargs,
                 )
 
             assert self.sconf["session_name"] == session.name

--- a/tests/fixtures/workspacebuilder/start_directory_session_path.yaml
+++ b/tests/fixtures/workspacebuilder/start_directory_session_path.yaml
@@ -1,0 +1,6 @@
+---
+session_name: sample_start_dir_session_path
+start_directory: '/usr'
+windows:
+  - panes:
+      -


### PR DESCRIPTION
This fixes a bug introduced in [2a4714e76b3a85b3391b05413f36623bcb1493f9](https://github.com/tmux-python/tmuxp/pull/809/commits/2279cb563908ff70024eb7bd18994499c82af7d6) (#809) whereby the `start_directory` session config was no longer passed to the `new_session` method when building a session. This resulted in the session working directory is not being set correctly, so new windows/panes created in the session, would not start in the expected directory.