### PR TITLE
fix(load): passthru of tmux config_file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,10 @@ $ pipx install --suffix=@next 'tmuxp' --pip-args '\--pre' --force
 
 <!-- Maintainers, insert changes / features for the next release here -->
 
+### Bug fix
+
+- cli: `tmuxp load`: Fix pass-through of config files (#843)
+
 ## tmuxp 1.18.0 (2022-10-30)
 
 We now refer to configs as workspaces. Other than just, just maintenance.

--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -254,7 +254,7 @@ def load_workspace(
     workspace_file: StrPath,
     socket_name: t.Optional[str] = None,
     socket_path: None = None,
-    tmux_config_file: None = None,
+    tmux_config_file: t.Optional[str] = None,
     new_session_name: t.Optional[str] = None,
     colors: t.Optional[int] = None,
     detached: bool = False,
@@ -382,7 +382,7 @@ def load_workspace(
     t = Server(  # create tmux server object
         socket_name=socket_name,
         socket_path=socket_path,
-        workspace_file=tmux_config_file,
+        config_file=tmux_config_file,
         colors=colors,
     )
 

--- a/tests/fixtures/tmux/tmux.conf
+++ b/tests/fixtures/tmux/tmux.conf
@@ -1,0 +1,1 @@
+display-message "Hello World"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,13 +92,13 @@ def test_load_workspace_passes_tmux_config(
     session = load_workspace(
         session_file,
         socket_name=server.socket_name,
-        tmux_config_file=FIXTURE_PATH / "tmux" / "tmux.conf",
+        tmux_config_file=str(FIXTURE_PATH / "tmux" / "tmux.conf"),
         detached=True,
     )
 
     assert isinstance(session, Session)
     assert isinstance(session.server, Server)
-    assert session.server.config_file == FIXTURE_PATH / "tmux" / "tmux.conf"
+    assert session.server.config_file == str(FIXTURE_PATH / "tmux" / "tmux.conf")
 
 
 def test_load_workspace_named_session(


### PR DESCRIPTION
f93179d9a6af8624ed98c44a5a8582b1c05c9f99 erroneously renamed the argument for `libtmux.server.Server` which is still called `config_file`.