### PR TITLE
fix(tests): explicitly state the shell to use

### DIFF
--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -880,6 +880,8 @@ def test_find_current_active_pane(server, monkeypatch):
             textwrap.dedent(
                 """
 session_name: Should not execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command: echo "___$((1 + 3))___"
@@ -893,6 +895,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should not execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command:
@@ -907,6 +911,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command: echo "___$((1 + 3))___"
@@ -919,6 +925,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command:
@@ -932,6 +940,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should not execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command:
@@ -946,6 +956,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should not execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command:
@@ -960,6 +972,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command: echo "___$((1 + 3))___"
@@ -972,6 +986,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command:
@@ -1033,6 +1049,8 @@ def test_load_workspace_enter(
             textwrap.dedent(
                 """
 session_name: Should not execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command:
@@ -1049,6 +1067,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should not execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command:
@@ -1065,6 +1085,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should not execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command:
@@ -1079,6 +1101,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should not execute
+options:
+  default-shell: /bin/bash
 windows:
 - panes:
   - shell_command:
@@ -1093,6 +1117,8 @@ windows:
             textwrap.dedent(
                 """
 session_name: Should not execute
+options:
+  default-shell: /bin/bash
 shell_command_before:
   - cmd: echo "sleeping before"
     sleep_before: .5


### PR DESCRIPTION
`tmux` uses the default login shell and thus tests might fail if this is not bash (or something compatible). Explicitly stating which shell to use circumvents issues arising from accidentally using another shell.