### PR TITLE
feat(builder): allow environments for windows and panes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,7 +17,28 @@ $ pipx install --suffix=@next 'tmuxp' --pip-args '\--pre' --force
 
 ## tmuxp 1.19.x (unreleased)
 
-- Notes on upcoming releases will be added here
+### What's new
+
+- #845: allow to configure window and pane specific environment variables
+
+  Having a setup like:
+  ```yaml
+  session_name: env-demo
+  environment:
+    DATABASE_URL: "sqlite3:///default.db"
+  windows:
+    - window_name: dev
+      environment:
+        DATABASE_URL: "sqlite3:///dev-1.db"
+      panes:
+        - pane
+        - environment:
+            DATABASE_URL: "sqlite3:///dev-2.db"
+  ```
+  will result in a window with two panes. In the first pane `$DATABASE_URL` is
+  `sqlite3:///dev-1.db`, while in the second pane it is `sqlite3://dev-2.db`.
+  Any freshly created window gets `sqlite3:///default.db` as this is what was
+  defined for the session.
 
 <!-- Maintainers, insert changes / features for the next release here -->
 

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -262,7 +262,9 @@ please make a ticket on the [issue tracker][issue tracker].
 
 ## Environment variables
 
-tmuxp will set session environment variables.
+tmuxp will set session, window and pane environment variables. Note that
+setting environment variables for windows and panes requires tmuxp 1.19 or
+newer.
 
 ````{tab} YAML
 

--- a/examples/session-environment.json
+++ b/examples/session-environment.json
@@ -2,15 +2,32 @@
   "environment": {
     "EDITOR": "/usr/bin/vim",
     "DJANGO_SETTINGS_MODULE": "my_app.settings.local",
-    "SERVER_PORT": "8009",
-  },  
+    "SERVER_PORT": "8009"
+  },
   "windows": [
     {
       "panes": [
-	"./manage.py runserver 0.0.0.0:${SERVER_PORT}"
-      ], 
+        "./manage.py runserver 0.0.0.0:${SERVER_PORT}"
+      ],
       "window_name": "Django project"
-    }, 
-  ], 
+    },
+    {
+      "environment": {
+        "DJANGO_SETTINGS_MODULE": "my_app.settings.local",
+        "SERVER_PORT": "8010"
+      },
+      "panes": [
+        "./manage.py runserver 0.0.0.0:${SERVER_PORT}",
+        {
+          "environment": {
+            "DJANGO_SETTINGS_MODULE": "my_app.settings.local-testing",
+            "SERVER_PORT": "8011"
+          },
+          "shell_command": "./manage.py runserver 0.0.0.0:${SERVER_PORT}"
+        }
+      ],
+      "window_name": "Another Django project"
+    }
+  ],
   "session_name": "Environment variables test"
 }

--- a/examples/session-environment.yaml
+++ b/examples/session-environment.yaml
@@ -7,3 +7,13 @@ windows:
   - window_name: Django project
     panes:
       - ./manage.py runserver 0.0.0.0:${SERVER_PORT}
+  - window_name: Another Django project
+    environment:
+      DJANGO_SETTINGS_MODULE: my_app.settings.local
+      SERVER_PORT: "8010"
+    panes:
+      - ./manage.py runserver 0.0.0.0:${SERVER_PORT}
+      - environment:
+          DJANGO_SETTINGS_MODULE: my_app.settings.local-testing
+          SERVER_PORT: "8011"
+        shell_command: ./manage.py runserver 0.0.0.0:${SERVER_PORT}

--- a/tests/fixtures/workspace/builder/environment_vars.yaml
+++ b/tests/fixtures/workspace/builder/environment_vars.yaml
@@ -1,9 +1,32 @@
 session_name: test env vars
-start_directory: '~'
+start_directory: "~"
 environment:
-  FOO: BAR
+  FOO: SESSION
   PATH: /tmp
 windows:
-- window_name: editor
+- window_name: no_overrides
   panes:
   - pane
+- window_name: window_overrides
+  environment:
+    FOO: WINDOW
+  panes:
+  - pane
+- window_name: pane_overrides
+  panes:
+  - environment:
+      FOO: PANE
+- window_name: both_overrides
+  environment:
+    FOO: WINDOW
+  panes:
+  - pane
+  - environment:
+      FOO: PANE
+# This test case it just needed for warnings issued in old versions of tmux.
+- window_name: both_overrides_on_first_pane
+  environment:
+    FOO: WINDOW
+  panes:
+  - environment:
+      FOO: PANE


### PR DESCRIPTION
This fixes #832.

Open question: what's the intended/desired fallback behavior?

1. (Currently implemented) If a pane doesn't have a `environment` configuration it uses the `environment` configuration of the window. This means that in order to change one environment variable (compared to the window) the full `environment` configuration needs to be duplicated. This also makes it possible to unset some variable if needed (compared to 2.) by skipping it int the configuration.
2. The `environment` of a pane is `ChainMap`ped with the one of the window (and possibly the session?) which means that the final `environment` contains all variables from both pane and window with the pane value taking precedence over the one from the window. This would avoid the possible duplication of 1. but makes it harder to unset an variable (in case an empty value doesn't suffice).
3. Something else? Proposals welcome.

Tests are currently failing as the check for old tmux versions isn't implemented yet.