### PR TITLE
build(deps): libtmux 0.19.1 -> 0.20.0

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -74,6 +74,12 @@ def monkeypatch_plugin_test_packages(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(scope="function")
+def session_params(session_params: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
+    session_params.update({"x": 800, "y": 600})
+    return session_params
+
+
+@pytest.fixture(scope="function")
 def socket_name(request: pytest.FixtureRequest) -> str:
     return "tmuxp_test%s" % next(namer)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -561,14 +561,14 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "libtmux"
-version = "0.20.0a0"
+version = "0.20.0a1"
 description = "Typed scripting library / ORM / API wrapper for tmux"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "libtmux-0.20.0a0-py3-none-any.whl", hash = "sha256:89dfb065f7138aca112567d233562902e621b2c369e7aaff61834f227a87632c"},
-    {file = "libtmux-0.20.0a0.tar.gz", hash = "sha256:0320c68deb33839d4dc11b1d1f8e9152d553e6b1467b5d16b22a29a851f19efa"},
+    {file = "libtmux-0.20.0a1-py3-none-any.whl", hash = "sha256:92af11bc02bf9d2ef7f56dc72a57f570b44d51819f35df5a43320d4776a97247"},
+    {file = "libtmux-0.20.0a1.tar.gz", hash = "sha256:bb9953e28d6384348d7488030531c8fab7506ee93795bdcc934d59bffe306ef1"},
 ]
 
 [[package]]
@@ -1707,4 +1707,4 @@ test = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "3ef9a9217032a60ae6f7354556d1baa8707078848bc4b968263509c4d177c9e9"
+content-hash = "d3d7c9aa3e0d67d8cee2dc4e2e65fa145108f689fb702079fe1d68a67beffe7b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -561,14 +561,14 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "libtmux"
-version = "0.20.0a1"
+version = "0.20.0"
 description = "Typed scripting library / ORM / API wrapper for tmux"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "libtmux-0.20.0a1-py3-none-any.whl", hash = "sha256:92af11bc02bf9d2ef7f56dc72a57f570b44d51819f35df5a43320d4776a97247"},
-    {file = "libtmux-0.20.0a1.tar.gz", hash = "sha256:bb9953e28d6384348d7488030531c8fab7506ee93795bdcc934d59bffe306ef1"},
+    {file = "libtmux-0.20.0-py3-none-any.whl", hash = "sha256:885ea6415bca1f23f55d5bdd638625419483e749912919841752d9c57179afb0"},
+    {file = "libtmux-0.20.0.tar.gz", hash = "sha256:5a4dcc01c52888970c0d515d63c7559b702055d3f53bec716c6a7de48fe88dd3"},
 ]
 
 [[package]]
@@ -1707,4 +1707,4 @@ test = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "d3d7c9aa3e0d67d8cee2dc4e2e65fa145108f689fb702079fe1d68a67beffe7b"
+content-hash = "b5f086b4a3ef354f56d4e9dbbef99a5aef9e50cbfd3ce1972df5111ecd173d32"

--- a/poetry.lock
+++ b/poetry.lock
@@ -561,14 +561,14 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "libtmux"
-version = "0.19.1"
+version = "0.20.0a0"
 description = "Typed scripting library / ORM / API wrapper for tmux"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "libtmux-0.19.1-py3-none-any.whl", hash = "sha256:0ab6986772555bca58c03400317b340975afc4b0acf5e614992b5e8aedf31517"},
-    {file = "libtmux-0.19.1.tar.gz", hash = "sha256:614fea2b09ed344735b4da2fe35e763ca2087e89a73c39d3663ed7f515fae356"},
+    {file = "libtmux-0.20.0a0-py3-none-any.whl", hash = "sha256:89dfb065f7138aca112567d233562902e621b2c369e7aaff61834f227a87632c"},
+    {file = "libtmux-0.20.0a0.tar.gz", hash = "sha256:0320c68deb33839d4dc11b1d1f8e9152d553e6b1467b5d16b22a29a851f19efa"},
 ]
 
 [[package]]
@@ -1707,4 +1707,4 @@ test = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "f7a4d54b648a94b51c269f80af6bd66a7b930e758be938b6733aa481d9db090d"
+content-hash = "3ef9a9217032a60ae6f7354556d1baa8707078848bc4b968263509c4d177c9e9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ tmuxp = 'tmuxp:cli.cli'
 
 [tool.poetry.dependencies]
 python = "^3.7"
-libtmux = "~0.20.0a0"
+libtmux = "~0.20.0a1"
 colorama = ">=0.3.9"
 PyYAML = "^6.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ tmuxp = 'tmuxp:cli.cli'
 
 [tool.poetry.dependencies]
 python = "^3.7"
-libtmux = "~0.20.0a1"
+libtmux = "~0.20.0"
 colorama = ">=0.3.9"
 PyYAML = "^6.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ tmuxp = 'tmuxp:cli.cli'
 
 [tool.poetry.dependencies]
 python = "^3.7"
-libtmux = "~0.19.1"
+libtmux = "~0.20.0a0"
 colorama = ">=0.3.9"
 PyYAML = "^6.0"
 

--- a/src/tmuxp/workspace/builder.py
+++ b/src/tmuxp/workspace/builder.py
@@ -9,7 +9,7 @@ import time
 import typing as t
 
 from libtmux._internal.query_list import ObjectDoesNotExist
-from libtmux.common import has_lt_version
+from libtmux.common import has_gte_version, has_lt_version
 from libtmux.pane import Pane
 from libtmux.server import Server
 from libtmux.session import Session
@@ -236,6 +236,9 @@ class WorkspaceBuilder:
                     new_session_kwargs["start_directory"] = self.session_config[
                         "start_directory"
                     ]
+                if has_gte_version("2.6"):
+                    new_session_kwargs["x"] = 800
+                    new_session_kwargs["y"] = 600
                 session = self.server.new_session(
                     session_name=self.session_config["session_name"],
                     **new_session_kwargs,


### PR DESCRIPTION
Includes libtmux 0.20.0

This changes `Server.new_session` to no longer set `-x` and `-y` by default, via https://github.com/tmux-python/libtmux/pull/469