### PR TITLE
build(deps): libtmux 0.20.0 -> 0.21.0 to avoid isolated crashes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,15 @@ $ pipx install --suffix=@next 'tmuxp' --pip-args '\--pre' --force
 
 <!-- Maintainers, insert changes / features for the next release here -->
 
+_Maintenance only, no bug fixes or features_
+
+### Internal improvements
+
+- libtmux 0.20.0 -> 0.21.0 (#865)
+
+  This updates the separator uses from libtmux to be a rarer character. See
+  [libtmux#475](https://github.com/tmux-python/libtmux/pull/475).
+
 ## tmuxp 1.26.0 (2023-01-15)
 
 _Maintenance only, no bug fixes or features_

--- a/poetry.lock
+++ b/poetry.lock
@@ -561,14 +561,14 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "libtmux"
-version = "0.20.0"
+version = "0.21.0"
 description = "Typed scripting library / ORM / API wrapper for tmux"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "libtmux-0.20.0-py3-none-any.whl", hash = "sha256:885ea6415bca1f23f55d5bdd638625419483e749912919841752d9c57179afb0"},
-    {file = "libtmux-0.20.0.tar.gz", hash = "sha256:5a4dcc01c52888970c0d515d63c7559b702055d3f53bec716c6a7de48fe88dd3"},
+    {file = "libtmux-0.21.0-py3-none-any.whl", hash = "sha256:b557b49549b40e11ffa23fafae8da85be6577feeecfbe4fac4402200cbaaf21c"},
+    {file = "libtmux-0.21.0.tar.gz", hash = "sha256:dc30b94ac25571c438a853ec75102fe5f1a2d7c8195b5ebdc6f71106760b15b3"},
 ]
 
 [[package]]
@@ -859,6 +859,13 @@ files = [
     {file = "Pillow-9.4.0-1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:b8c2f6eb0df979ee99433d8b3f6d193d9590f735cf12274c108bd954e30ca858"},
     {file = "Pillow-9.4.0-1-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b70756ec9417c34e097f987b4d8c510975216ad26ba6e57ccb53bc758f490dab"},
     {file = "Pillow-9.4.0-1-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:43521ce2c4b865d385e78579a082b6ad1166ebed2b1a2293c3be1d68dd7ca3b9"},
+    {file = "Pillow-9.4.0-2-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:9d9a62576b68cd90f7075876f4e8444487db5eeea0e4df3ba298ee38a8d067b0"},
+    {file = "Pillow-9.4.0-2-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:87708d78a14d56a990fbf4f9cb350b7d89ee8988705e58e39bdf4d82c149210f"},
+    {file = "Pillow-9.4.0-2-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8a2b5874d17e72dfb80d917213abd55d7e1ed2479f38f001f264f7ce7bae757c"},
+    {file = "Pillow-9.4.0-2-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:83125753a60cfc8c412de5896d10a0a405e0bd88d0470ad82e0869ddf0cb3848"},
+    {file = "Pillow-9.4.0-2-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:9e5f94742033898bfe84c93c831a6f552bb629448d4072dd312306bab3bd96f1"},
+    {file = "Pillow-9.4.0-2-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:013016af6b3a12a2f40b704677f8b51f72cb007dac785a9933d5c86a72a7fe33"},
+    {file = "Pillow-9.4.0-2-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:99d92d148dd03fd19d16175b6d355cc1b01faf80dae93c6c3eb4163709edc0a9"},
     {file = "Pillow-9.4.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:2968c58feca624bb6c8502f9564dd187d0e1389964898f5e9e1fbc8533169157"},
     {file = "Pillow-9.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c5c1362c14aee73f50143d74389b2c158707b4abce2cb055b7ad37ce60738d47"},
     {file = "Pillow-9.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd752c5ff1b4a870b7661234694f24b1d2b9076b8bf337321a814c612665f343"},
@@ -1717,4 +1724,4 @@ test = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "b5f086b4a3ef354f56d4e9dbbef99a5aef9e50cbfd3ce1972df5111ecd173d32"
+content-hash = "7b9088ff6e561abb7d378d62f723458161dbdcacbeb12d79a98ec54834a316dd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ tmuxp = 'tmuxp:cli.cli'
 
 [tool.poetry.dependencies]
 python = "^3.7"
-libtmux = "~0.20.0"
+libtmux = "~0.21.0"
 colorama = ">=0.3.9"
 PyYAML = "^6.0"
 


### PR DESCRIPTION
This adjusts the default separator for formats to be a pipe (somewhat common in the terminal) to a rare character - ␞. This will avoid crashes with various libtmux lookups.

See also:
- https://github.com/tmux-python/libtmux/pull/475
- https://github.com/tmux-python/libtmux/releases/tag/v0.21.0