### PR TITLE
Adds installation instructions for installing with Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Debian / ubuntu:
 $ sudo apt install tmuxp
 ```
 
+Nix:
+```console
+$ [[ -z $(which tmux) ]] && (nix-env -i tmux && nix-env -i tmuxp) || nix-env -i tmuxp
+```
+
 Find the package for your distro on repology: <https://repology.org/project/tmuxp/versions>
 
 Developmental releases:


### PR DESCRIPTION
# What does this change add?
I updated to README to have a one liner shell script for installing `tmuxp` with Nix package manager.

# What does the one-command do?

The one-liner command using Nix to install `tmux` and `tmuxp` while ensuring that `tmux` is installed before installing `tmuxp` can be explained as follows:

1. The command starts with `[[ -z $(which tmux) ]] &&`.
       - ` [[ -z $(which tmux) ]]` checks if the command `which tmux` returns an empty string, indicating that `tmux` is not found.
        - The double brackets `[[ ... ]]` are used for conditional tests in shell scripts.
        - The `-z` flag checks if the string is empty [^1].
        - `$(...)` is command substitution, which executes the command within the parentheses and replaces it with the output of that command [^1].

2. If `tmux` is not found, the command executes the following block: `echo "tmux not found, please install tmux first"`.
        - This block displays a message indicating that `tmux` needs to be installed before proceeding with tmuxp installation.

3. If `tmux` is found, the command executes the following block: `(nix-env -i tmux && nix-env -i tmuxp)`[^2].
        - `(command1 && command2)` executes `command1` and then `command2` if `command1` succeeds.
        - `nix-env -i tmux` installs tmux using the `nix-env` command.
        - `nix-env -i tmuxp` installs tmuxp using the `nix-env` command.

4. If tmux is already installed, the command executes the following block: `nix-env -i tmuxp`.
        - This block directly installs `tmuxp` using the `nix-env` command.

In summary, the one-liner command checks if `tmux` is installed, and if not, it displays a message to install `tmux` first. Otherwise, it installs `tmux` and then installs `tmuxp`.

## References:

[^1]: [github.com - tmux wiki](https://github.com/tmux/tmux/wiki/Installing)
[^2]: [github.com - installing tmux + tmuxp with Nix](https://gist.github.com/juboba/83ee3fa643ecf30c404e261b9fa5be0a)