### PR TITLE
Implements `if` conditions for pane and window

### DIFF
--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -289,7 +289,7 @@ newer and tmux 3.0 or newer.
 
 ## `if` conditions
 
-tmuxp enables one to optionally open windows / panes based on coditions. The `if` conditions can appears in the configuration for window or pane.
+tmuxp enables one to optionally open windows / panes based on conditions. The `if` conditions can appears in the configuration for window or pane.
 
 ````{tab} YAML
 
@@ -320,7 +320,7 @@ should produce **only** a window with upper and lower split panes (others should
 $ show_htop=false tmuxp load examples/if-conditions.yaml
 ```
 
-will insteads suppress the `htop` command pane and resulting in a different behaviour.
+will instead suppress the `htop` command pane and resulting in a different behaviour.
 
 ## Focusing
 

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -287,6 +287,41 @@ newer and tmux 3.0 or newer.
 
 ````
 
+## `if` conditions
+
+tmuxp enables one to optionally open windows / panes based on coditions. The `if` conditions can appears in the configuration for window or pane.
+
+````{tab} YAML
+
+```{literalinclude} ../../examples/if-conditions.yaml
+:language: yaml
+
+```
+````
+
+````{tab} JSON
+
+```{literalinclude} ../../examples/if-conditions.json
+:language: json
+
+```
+
+````
+
+In the example, running the example
+
+```console
+$ tmuxp load examples/if-conditions.yaml
+```
+
+should produce **only** a window with upper and lower split panes (others should have `if` conditions that evaluates to false). This example allows for on-demand pane showing, where
+
+```console
+$ show_htop=false tmuxp load examples/if-conditions.yaml
+```
+
+will insteads suppress the `htop` command pane and resulting in a different behaviour.
+
 ## Focusing
 
 tmuxp allows `focus: true` for assuring windows and panes are attached /

--- a/examples/if-conditions-test.yaml
+++ b/examples/if-conditions-test.yaml
@@ -3,6 +3,7 @@ environment:
   foo: 'false'
   bar: '1'
   F: '0'
+  MY_VAR: myfoobar
 windows:
   - window_name: window all false
     panes:
@@ -46,3 +47,7 @@ windows:
       - if: ${non_existing_var}
         shell_command:
           - echo pane 9
+      - if:
+          shell: echo ${MY_VAR} | grep -q foo
+        shell_command:
+          - echo pane 10

--- a/examples/if-conditions-test.yaml
+++ b/examples/if-conditions-test.yaml
@@ -1,0 +1,48 @@
+session_name: if conditions test conditions
+environment:
+  foo: 'false'
+  bar: '1'
+  F: '0'
+windows:
+  - window_name: window all false
+    panes:
+      - if: ${foo}
+        shell_command:
+          - echo pane 1
+      - if:
+          shell: '[ 1 -gt 2 ]'
+        shell_command:
+          - echo pane 2
+      - if:
+          shell_var: ${F}
+  - window_name: window 2 of 3 true
+    panes:
+      - if:
+          shell: '[ "foo" = "bar" ]'
+        shell_command:
+          - echo pane 3
+      - if:
+          shell: '[ "hello" != "byte" ]'
+        shell_command:
+          - echo pane 4
+      - if:
+          python: '2**4 == 16'
+        shell_command:
+          - echo pane 5
+  - window_name: window 2 of 4 true
+    panes:
+      - if:
+          shell_var: 'FALSE'
+        shell_command:
+          - echo pane 6
+      - if:
+          shell_var: ${bar}
+        shell_command:
+          - echo pane 7
+      - if:
+          python: import os; not os.path.isdir('/a/very/random/path')
+        shell_command:
+          - echo pane 8
+      - if: ${non_existing_var}
+        shell_command:
+          - echo pane 9

--- a/examples/if-conditions.json
+++ b/examples/if-conditions.json
@@ -7,9 +7,7 @@
   "windows": [
     {
       "window_name": "window 1 ${ha} $Foo",
-      "if": {
-        "shell": "${Foo}"
-      },
+      "if": "${Foo}",
       "panes": [
         {
           "shell_command": [
@@ -24,22 +22,25 @@
       "panes": [
         {
           "if": {
-            "python": "1+1==3"
+            "shell": "[ 5 -lt 4 ]"
           },
           "shell_command": [
             "echo the above is a false statement"
           ]
         },
         {
+          "if": {
+            "python": "import os; os.path.isdir('${PWD}')"
+          },
           "shell_command": [
-            "echo no condition",
+            "echo \"checking for PWD (${PWD}) is a directory in python\"",
             "python -m http.server"
           ]
         },
         {
           "if": "${show_htop}",
           "shell_command": [
-            "echo the above is a true statement (by default), but can be disabled on-demand",
+            "echo \"the above is a true statement (by default), but can be disabled on-demand\"",
             "htop"
           ]
         }

--- a/examples/if-conditions.json
+++ b/examples/if-conditions.json
@@ -1,0 +1,49 @@
+{
+  "session_name": "if conditions test",
+  "environment": {
+    "Foo": "false",
+    "show_htop": "true"
+  },
+  "windows": [
+    {
+      "window_name": "window 1 ${ha} $Foo",
+      "if": {
+        "shell": "${Foo}"
+      },
+      "panes": [
+        {
+          "shell_command": [
+            "echo \"this shouldn't shows up\""
+          ]
+        },
+        "echo neither should this $Foo"
+      ]
+    },
+    {
+      "window_name": "window 2",
+      "panes": [
+        {
+          "if": {
+            "python": "1+1==3"
+          },
+          "shell_command": [
+            "echo the above is a false statement"
+          ]
+        },
+        {
+          "shell_command": [
+            "echo no condition",
+            "python -m http.server"
+          ]
+        },
+        {
+          "if": "${show_htop}",
+          "shell_command": [
+            "echo the above is a true statement (by default), but can be disabled on-demand",
+            "htop"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/if-conditions.json
+++ b/examples/if-conditions.json
@@ -11,7 +11,7 @@
       "panes": [
         {
           "shell_command": [
-            "echo \"this shouldn't shows up\""
+            "echo \"this shouldn't show up\""
           ]
         },
         "echo neither should this $Foo"

--- a/examples/if-conditions.yaml
+++ b/examples/if-conditions.yaml
@@ -5,25 +5,26 @@ environment:
 windows:
   # the following would not shows up as it evaluates to false
   - window_name: window 1 ${ha} $Foo
-    if:
-      shell: ${Foo}
+    if: ${Foo}
     panes:
       - shell_command:
           - echo "this shouldn't shows up"
       - echo neither should this $Foo
   - window_name: window 2
     panes:
-      # should not shows up
+      # should not shows up; using shell expression
       - if:
-          python: 1+1==3
+          shell: '[ 5 -lt 4 ]'
         shell_command:
           - echo the above is a false statement
-      # no if conditions
-      - shell_command:
-          - echo no condition
+      # python conditions
+      - if:
+          python: import os; os.path.isdir('${PWD}')
+        shell_command:
+          - echo "checking for PWD (${PWD}) is a directory in python"
           - python -m http.server
       # display by default, but can be disabled by running `show_htop=false tmuxp load .....`
       - if: ${show_htop}
         shell_command:
-          - echo the above is a true statement (by default), but can be disabled on-demand
+          - echo "the above is a true statement (by default), but can be disabled on-demand"
           - htop

--- a/examples/if-conditions.yaml
+++ b/examples/if-conditions.yaml
@@ -1,0 +1,29 @@
+session_name: if conditions test
+environment:
+  Foo: 'false'
+  show_htop: 'true'
+windows:
+  # the following would not shows up as it evaluates to false
+  - window_name: window 1 ${ha} $Foo
+    if:
+      shell: ${Foo}
+    panes:
+      - shell_command:
+          - echo "this shouldn't shows up"
+      - echo neither should this $Foo
+  - window_name: window 2
+    panes:
+      # should not shows up
+      - if:
+          python: 1+1==3
+        shell_command:
+          - echo the above is a false statement
+      # no if conditions
+      - shell_command:
+          - echo no condition
+          - python -m http.server
+      # display by default, but can be disabled by running `show_htop=false tmuxp load .....`
+      - if: ${show_htop}
+        shell_command:
+          - echo the above is a true statement (by default), but can be disabled on-demand
+          - htop

--- a/examples/if-conditions.yaml
+++ b/examples/if-conditions.yaml
@@ -12,12 +12,12 @@ windows:
       - echo neither should this $Foo
   - window_name: window 2
     panes:
-      # should not shows up; using shell expression
+      # shell expression condition; should not show up
       - if:
           shell: '[ 5 -lt 4 ]'
         shell_command:
           - echo the above is a false statement
-      # python conditions
+      # python condition
       - if:
           python: import os; os.path.isdir('${PWD}')
         shell_command:

--- a/examples/if-conditions.yaml
+++ b/examples/if-conditions.yaml
@@ -3,12 +3,12 @@ environment:
   Foo: 'false'
   show_htop: 'true'
 windows:
-  # the following would not shows up as it evaluates to false
+  # the following would not show up as it evaluates to false
   - window_name: window 1 ${ha} $Foo
     if: ${Foo}
     panes:
       - shell_command:
-          - echo "this shouldn't shows up"
+          - echo "this shouldn't show up"
       - echo neither should this $Foo
   - window_name: window 2
     panes:

--- a/examples/if-conditions.yaml
+++ b/examples/if-conditions.yaml
@@ -19,7 +19,7 @@ windows:
           - echo the above is a false statement
       # python condition
       - if:
-          python: import os; os.path.isdir('${PWD}')
+          python: import os; os.path.isdir(os.path.expandvars('${PWD}'))
         shell_command:
           - echo "checking for PWD (${PWD}) is a directory in python"
           - python -m http.server

--- a/src/tmuxp/workspace/loader.py
+++ b/src/tmuxp/workspace/loader.py
@@ -157,6 +157,9 @@ def expand(
             if any(val.startswith(a) for a in [".", "./"]):
                 val = str(cwd / val)
             workspace_dict["environment"][key] = val
+            if key not in os.environ:
+                # using user provided environment variable as default vars
+                os.environ[key] = val
     if "global_options" in workspace_dict:
         for key in workspace_dict["global_options"]:
             val = workspace_dict["global_options"][key]

--- a/src/tmuxp/workspace/loader.py
+++ b/src/tmuxp/workspace/loader.py
@@ -54,7 +54,12 @@ def optional_windows_and_pane(
         }:
             return False
     if "shell" in if_cond:
-        if subprocess.run(if_cond["shell"], shell=True, check=False).returncode != 0:
+        if (
+            subprocess.run(
+                expandshell(if_cond["shell"]), shell=True, check=False
+            ).returncode
+            != 0
+        ):
             return False
     if "python" in if_cond:
         # assign the result of the last statement from the python snippet

--- a/src/tmuxp/workspace/loader.py
+++ b/src/tmuxp/workspace/loader.py
@@ -53,14 +53,15 @@ def optional_windows_and_pane(
             "t",
         }:
             return False
-    if "shell" in if_cond:
-        if (
-            subprocess.run(
-                expandshell(if_cond["shell"]), shell=True, check=False
-            ).returncode
-            != 0
-        ):
-            return False
+    if "shell" in if_cond and (
+        subprocess.run(
+            expandshell(if_cond["shell"]),
+            shell=True,
+            check=False,
+        ).returncode
+        != 0
+    ):
+        return False
     if "python" in if_cond:
         # assign the result of the last statement from the python snippet
         py_statements = if_cond["python"].split(";")

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -586,7 +586,7 @@ def test_if_conditions(
 
     window3 = session.windows.get(window_name="window 2 of 4 true")
     assert window3 is not None
-    assert len(window3.panes) == 2
+    assert len(window3.panes) == 3
 
 
 def test_start_directory(session: Session, tmp_path: pathlib.Path) -> None:

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -563,6 +563,34 @@ def test_blank_pane_spawn(
     assert len(window4.panes) == 2
 
 
+def test_if_conditions(
+    session: Session,
+) -> None:
+    """
+    Test various ways of spawning panes with conditions from a tmuxp configuration.
+    """
+    yaml_workspace_file = EXAMPLE_PATH / "if-conditions-test.yaml"
+    test_config = ConfigReader._from_file(yaml_workspace_file)
+
+    test_config = loader.expand(test_config)
+    builder = WorkspaceBuilder(session_config=test_config, server=session.server)
+    builder.build(session=session)
+
+    assert session == builder.session
+
+    with pytest.raises(ObjectDoesNotExist):
+        window1 = session.windows.get(window_name="window all false")
+        assert window1 is None
+
+    window2 = session.windows.get(window_name="window 2 of 3 true")
+    assert window2 is not None
+    assert len(window2.panes) == 2
+
+    window3 = session.windows.get(window_name="window 2 of 4 true")
+    assert window3 is not None
+    assert len(window3.panes) == 2
+
+
 def test_start_directory(session: Session, tmp_path: pathlib.Path) -> None:
     """Test workspace builder setting start_directory relative to current directory."""
     test_dir = tmp_path / "foo bar"

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -566,9 +566,7 @@ def test_blank_pane_spawn(
 def test_if_conditions(
     session: Session,
 ) -> None:
-    """
-    Test various ways of spawning panes with conditions from a tmuxp configuration.
-    """
+    """Test various ways of spawning panes with conditions from a tmuxp configuration."""
     yaml_workspace_file = EXAMPLE_PATH / "if-conditions-test.yaml"
     test_config = ConfigReader._from_file(yaml_workspace_file)
 


### PR DESCRIPTION
Closes #741 

This implements both `shell` and `python` conditions. 
- `if` can be a:
	- string or, (short-hand for `shell` key)
	- dict that contains 
		- `python` or 
		- `shell` key.

- A `python` key will be evaluated as a python expression, and will test for its pythonic truthfulness
- A `shell` key will test as a shell variable and any of the following will be evaluated to true: `("y", "yes", "1", "on", "true", "t")` (case-insensitivity)


```yaml
session_name: if conditions test
environment:
  Foo: 'false'
  show_htop: 'true'
windows:
  # the following would not shows up as it evaluates to false
  - window_name: window 1 ${ha} $Foo
    if:
      shell: ${Foo}
    panes:
      - shell_command:
          - echo "this shouldn't shows up"
      - echo neither should this $Foo
  - window_name: window 2
    panes:
      # should not shows up
      - if:
          python: 1+1==3
        shell_command:
          - echo the above is a false statement
      # no if conditions
      - shell_command:
          - echo no condition
          - python -m http.server
      # display by default, but can be disabled by running `show_htop=false tmuxp load .....`
      - if: ${show_htop}
        shell_command:
          - echo the above is a true statement (by default), but can be disabled on-demand
          - htop
```

In the example, by default, `show_htop=true`, but since it's a shell variable, it can be override by user. Hence, use can on-deamnd customise their pane/window configuration by

```sh
tmuxp load examples/if-conditions.yaml
```
and
```sh
show_htop=false tmuxp load examples/if-conditions.yaml
```
which will have different behaviour, for different use-cases