### PR TITLE
tmux: Add tmux 3.6 to testgrid

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.14']
-        tmux-version: ['2.6', '2.7', '2.8', '3.0a', '3.1b', '3.2a', '3.3a', '3.4', '3.5', 'master']
+        tmux-version: ['2.6', '2.7', '2.8', '3.0a', '3.1b', '3.2a', '3.3a', '3.4', '3.5', '3.6', 'master']
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGES
+++ b/CHANGES
@@ -31,7 +31,11 @@ $ pipx install --suffix=@next 'tmuxp' --pip-args '\--pre' --force
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
-- _Future release notes will be placed here_
+### What's new
+
+#### tmux 3.6 support (#989)
+
+Added tmux 3.6 to test grid.
 
 ## tmuxp 1.56.0 (2025-11-01)
 


### PR DESCRIPTION
# Changes

## Bump tmux max version to tmux 3.6

See release notes: https://github.com/tmux/tmux/blob/3.6/CHANGES#L1