### PR TITLE
py(deps) Bump libtmux 0.56.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,15 @@ $ pipx install \
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Breaking changes
+
+#### **libtmux** minimum bumped from `~=0.55.0` to `~=0.56.0` (#1038)
+
+  Picks up two releases: 0.55.1 (test-fixture socket cleanup) and
+  0.56.0 (broader tmux command coverage — interactive commands,
+  buffer I/O, key bindings, and window/pane manipulation, all
+  available to scripts run via `tmuxp shell`).
+
 ### Documentation
 
 - Visual improvements to API docs from [gp-sphinx](https://gp-sphinx.git-pull.com)-based Sphinx packages (#1035)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ include = [
   { path = "conftest.py", format = "sdist" },
 ]
 dependencies = [
-  "libtmux~=0.55.0",
+  "libtmux~=0.56.0",
   "PyYAML>=6.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ build-backend = "hatchling.build"
 gp-libs = false
 gp-furo-theme = false
 gp-sphinx = false
+libtmux = false
 sphinx-autodoc-api-style = false
 sphinx-autodoc-argparse = false
 sphinx-autodoc-docutils = false

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
+libtmux = false
 gp-sphinx = false
 sphinx-autodoc-sphinx = false
 sphinx-autodoc-api-style = false
@@ -413,7 +414,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -614,11 +615,11 @@ wheels = [
 
 [[package]]
 name = "libtmux"
-version = "0.55.1"
+version = "0.56.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/01/fa4f839045d32576d4c193d85ba37e47908fea8227f18800847f589e2476/libtmux-0.55.1.tar.gz", hash = "sha256:dcee950537b8bda4337267bc2cb62b434c4c8da3a75c1546151674238ef14e20", size = 439372, upload-time = "2026-04-19T18:25:39.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/62/896e1e0412dd76c88926604d5a231feb9b116d6f32abe19054e244504dbc/libtmux-0.56.0.tar.gz", hash = "sha256:bddf52214405e4f64850826d44cbc958d4a01c53432983cee0e2856bdbbaaedb", size = 476168, upload-time = "2026-05-10T13:40:23.774Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/2e/819d7414b96f19ec4cafda95555246bdb9766dd7c0519b5b1bf4495789f7/libtmux-0.55.1-py3-none-any.whl", hash = "sha256:4382667d508610bdf71a7cc07d7a561d402fa2d5621cce299e7ae97b0cdcb93b", size = 80679, upload-time = "2026-04-19T18:25:37.61Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ce/4319c912164fa142956c73ba50ed6f2aac2ca7cced2e96c8320114f1c937/libtmux-0.56.0-py3-none-any.whl", hash = "sha256:ddf70de0f287666fb0f02082732f28eed46450de1828c995da3de2b12042ab60", size = 97768, upload-time = "2026-05-10T13:40:22.189Z" },
 ]
 
 [[package]]
@@ -1667,7 +1668,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "libtmux", specifier = "~=0.55.0" },
+    { name = "libtmux", specifier = "~=0.56.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Bump `libtmux` from `~=0.55.0` to `~=0.56.0`
- Whitelist `libtmux` from the `exclude-newer` cooldown so contributor `uv sync` works against the new pin without waiting 3 days
- Picks up libtmux 0.55.1 (test-fixture socket-cleanup fix) and 0.56.0 (50+ new tmux command wrappers, `move_window()` auto-refresh fix, `control_mode` pytest fixture, `TMUX_MAX_VERSION` -> 3.7)
- No tmuxp code or test changes needed — v0.56.0 is purely additive on the surface tmuxp imports, and tmuxp's only `Window.move_window()` call doesn't read post-move attributes so the upstream auto-refresh fix is a free correctness improvement

## Upstream changes

### libtmux 0.56.0 (2026-05-10)

**What's new (#653)**

- **Interactive tmux commands now scriptable**: new wrappers for the commands that previously required hand-rolled `Server.cmd()` calls — `Pane.display_popup`, `Server.display_menu`, `Server.command_prompt`, `Server.confirm_before`, `Session.detach_client`, `Server.detach_client`, `Server.detach_all_clients`, `Pane.display_panes`, plus the `choose_*` family (`choose_buffer`, `choose_client`, `choose_tree`). The three `detach-client` wrappers each map to one tmux flag group with a single subprocess call.
- **tmux buffer I/O suite**: `Server.set_buffer`, `show_buffer`, `delete_buffer`, `save_buffer`, `load_buffer`, `list_buffers`, plus `Pane.paste_buffer` round-trip pane content through named tmux buffers.
- **Key bindings and shell execution**: `Server` gains `bind_key`, `unbind_key`, `list_keys`, `list_commands`, `run_shell`, `if_shell`, `source_file`, `list_clients`, `start_server`, `lock_server`, `lock_client`, `refresh_client`, `suspend_client`, `server_access`, `show_messages`, `show_prompt_history`, `clear_prompt_history`. `Session` gains `lock_session`. `Pane` gains `send_prefix`.
- **Window/pane manipulation parity**: new `Window.swap`, `link`, `unlink`, `respawn`, `last_pane`, `next_layout`, `previous_layout`, `rotate`; new `Pane.swap`, `join`, `break_pane`, `move`, `pipe`, `clear_history`, `respawn`, `copy_mode`, `clock_mode`, `customize_mode`, `find_window`; new `Server.wait_for`, `Session.last_window`, `next_window`, `previous_window`.
- **Filled-in flag coverage on existing methods**: `Pane.send_keys` (literal, hex, key-name, format, client), `Pane.split` (`percentage=`), `Pane.capture_pane` (alternate-screen, quiet, write-to-buffer), `Pane.display_message`, `Pane.display_popup` (`target_client=`, `-c`), `Window.move_window` (after, before, kill, renumber), `Window.select_layout` (spread, next, previous), `Server.new_session`, `Session.new_window`, `Server.set_environment`, `Server.show_options` (`quiet=`).
- **`control_mode` pytest fixture**: spawns a real `tmux -C` client attached to the session so commands that require an attached client are testable without a TTY.

**Bug fixes (#653)**

- `Window.move_window()` now refreshes the moved window automatically; previously the `Window` object pointed at its pre-move index until a manual `refresh()`. tmuxp's only call site (`workspace/builder.py:629`) doesn't read post-move attributes, so this is a free correctness improvement.

**Development (#653)**

- `TMUX_MAX_VERSION` bumped to `"3.7"`, unlocking method coverage already version-gated for tmux 3.7 (notably `command_prompt(bspace_exit=)` and `show_messages(terminals=, jobs=)`). No effect on installations running tmux 3.6 or earlier.

### libtmux 0.55.1 (2026-04-19)

- `pytest_plugin`: `server` and `TestServer` fixture finalizers now `unlink(2)` the tmux socket from `/tmp/tmux-<uid>/` in addition to `server.kill()`. tmux doesn't reliably unlink its socket on non-graceful exit, so long-lived dev machines were accumulating 10k+ stale `libtmux_test*` entries (#661, fixes #660).

## Changes in this PR

- **Whitelist commit** (`1d6bb889`): adds `libtmux = false` to `[tool.uv.exclude-newer-package]` in `pyproject.toml` so the rolling 3-day cooldown doesn't block contributor `uv sync` against the new pin. Mirrors the precedent set in `6c0a0b2d` for the gp-* dep surface.
- **Package bump** (`3754a060`): `pyproject.toml` `libtmux~=0.55.0` -> `libtmux~=0.56.0`; `uv.lock` regenerated via `uv lock --upgrade-package libtmux` (other packages unchanged).
- **No code changes**: tmuxp imports only stable APIs unaffected by v0.56.0.
- **No test changes**: existing test surface continues to work against the new wheel.

## Test plan

- [ ] `uv run py.test` passes locally
- [ ] `uv run mypy` passes
- [ ] `uv run ruff check .` passes
- [ ] CI green on all matrix legs (CI doesn't carry the user-level cooldown so it won't need the whitelist to resolve)

Release: https://github.com/tmux-python/libtmux/releases/tag/v0.56.0
Changelog: https://libtmux.git-pull.com/history.html