### PR TITLE
refactor(cli/load,tests) Migrate display-message to typed wrapper

### DIFF
--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -222,8 +222,10 @@ def _reattach(builder: WorkspaceBuilderProtocol, colors: Colors | None = None) -
     assert builder.session is not None
     for plugin in builder.plugins:
         plugin.reattach(builder.session)
-        proc = builder.session.cmd("display-message", "-p", "'#S'")
-        for line in proc.stdout:
+        active_pane = builder.session.active_pane
+        assert active_pane is not None
+        lines = active_pane.display_message("'#S'", get_text=True)
+        for line in lines:
             tmuxp_echo(colors.info(line) if colors else line)
             logger.debug(
                 "reattach display-message output",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -170,6 +170,8 @@ def test_reattach_plugins(
         _reattach(builder)
 
     assert builder.session is not None
-    proc = builder.session.cmd("display-message", "-p", "'#S'")
+    active_pane = builder.session.active_pane
+    assert active_pane is not None
+    lines = active_pane.display_message("'#S'", get_text=True)
 
-    assert proc.stdout[0] == "'plugin_test_r'"
+    assert lines[0] == "'plugin_test_r'"

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -825,8 +825,10 @@ def test_plugin_system_before_workspace_builder(
 
     builder.build(session=session)
 
-    proc = session.cmd("display-message", "-p", "'#S'")
-    assert proc.stdout[0] == "'plugin_test_bwb'"
+    active_pane = session.active_pane
+    assert active_pane is not None
+    lines = active_pane.display_message("'#S'", get_text=True)
+    assert lines[0] == "'plugin_test_bwb'"
 
 
 def test_plugin_system_on_window_create(
@@ -848,8 +850,10 @@ def test_plugin_system_on_window_create(
 
     builder.build(session=session)
 
-    proc = session.cmd("display-message", "-p", "'#W'")
-    assert proc.stdout[0] == "'plugin_test_owc'"
+    active_pane = session.active_pane
+    assert active_pane is not None
+    lines = active_pane.display_message("'#W'", get_text=True)
+    assert lines[0] == "'plugin_test_owc'"
 
 
 def test_plugin_system_after_window_finished(
@@ -871,8 +875,10 @@ def test_plugin_system_after_window_finished(
 
     builder.build(session=session)
 
-    proc = session.cmd("display-message", "-p", "'#W'")
-    assert proc.stdout[0] == "'plugin_test_awf'"
+    active_pane = session.active_pane
+    assert active_pane is not None
+    lines = active_pane.display_message("'#W'", get_text=True)
+    assert lines[0] == "'plugin_test_awf'"
 
 
 def test_plugin_system_on_window_create_multiple_windows(
@@ -947,15 +953,18 @@ def test_plugin_system_multiple_plugins(
 
     builder.build(session=session)
 
+    active_pane = session.active_pane
+    assert active_pane is not None
+
     # Drop through to the before_script plugin hook
-    proc = session.cmd("display-message", "-p", "'#S'")
-    assert proc.stdout[0] == "'plugin_test_bwb'"
+    lines = active_pane.display_message("'#S'", get_text=True)
+    assert lines[0] == "'plugin_test_bwb'"
 
     # Drop through to the after_window_finished. This won't succeed
     # unless on_window_create succeeds because of how the test plugin
     # override methods are currently written
-    proc = session.cmd("display-message", "-p", "'#W'")
-    assert proc.stdout[0] == "'mp_test_awf'"
+    lines = active_pane.display_message("'#W'", get_text=True)
+    assert lines[0] == "'mp_test_awf'"
 
 
 def test_load_configs_same_session(


### PR DESCRIPTION
## Summary

- Drop the last two `cmd("display-message", "-p", ...)` escape hatches in the codebase: one in production (`cli/load._reattach`), six in test code (the plugin-system suite).
- Same tmux invocation under the hood, just routed through libtmux's typed `Pane.display_message(cmd, get_text=True)` wrapper. No behavior change.
- Follows the libtmux 0.56.0 bump in #1038 — the wrapper itself has been around since 0.55.0, but with 0.56.0 now landed there's no remaining reason to keep the cmd() escape for this particular subcommand.

## Why now

PR #1038 broadened the `Pane.display_message` flag coverage in libtmux 0.56.0 (`format_string=`, `verbose=`, `delay=`, `notify=`, `target_client=`). While auditing tmuxp for spots that could move to the new typed surface, the only remaining `cmd()` escape in production turned out to be the post-reattach session-name echo loop in `cli/load._reattach`. Five of the six other usages were in tests asserting on session/window names via the same idiom — leaving them on `cmd()` while production migrated would split the call shape across the codebase.

The migration itself doesn't depend on a 0.56.0-only API; this is consistency cleanup that 0.56.0's broader display_message surface made an obvious moment to do.

## Changes in this PR

### `c54893e5` — `cli/load(refactor[_reattach])` Use `Pane.display_message` wrapper

Production change. Replaces:

```python
proc = builder.session.cmd("display-message", "-p", "'#S'")
for line in proc.stdout:
    ...
```

with:

```python
active_pane = builder.session.active_pane
assert active_pane is not None
lines = active_pane.display_message("'#S'", get_text=True)
for line in lines:
    ...
```

The narrowing assert mirrors the existing `assert builder.session is not None` already at the top of `_reattach()`. tmux's `display-message` without `-t` defaults to the session's active pane, so the underlying invocation is byte-for-byte identical.

### `46b52f16` — `tests(refactor[plugin_system])` Use `Pane.display_message` wrapper

Migrates six test sites in `tests/cli/test_cli.py::test_reattach_plugins` and four `test_plugin_system_*` checks in `tests/workspace/test_builder.py` to the same typed wrapper. Hoists `active_pane` once in the multi-query test that asserts on both `'#S'` and `'#W'` (replaces two separate `cmd()` roundtrips with two calls on the same pane reference).

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` clean before each commit
- [x] `uv run ruff format .` clean before each commit
- [x] `uv run mypy` clean before each commit (the narrowing assert was load-bearing — without it, `Pane | None` typing rejects the call)
- [x] `uv run py.test --reruns 0 -vvv` — 797 passed, 2 skipped, before each commit
- [x] `just build-docs` succeeds before each commit
- [x] No remaining `cmd("display-message", ...)` calls anywhere in `src/` or `tests/` (verified via `grep -rn 'cmd("display-message"' src/ tests/`)