### PR TITLE
workspace(perf,refactor) Bulk set-option helper + 10ms readiness polling

### DIFF
--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -9,6 +9,7 @@ import time
 import typing as t
 
 from libtmux._internal.query_list import ObjectDoesNotExist
+from libtmux.options import handle_option_error
 from libtmux.pane import Pane
 from libtmux.server import Server
 from libtmux.session import Session
@@ -25,7 +26,7 @@ from tmuxp.workspace.options import (
 )
 
 if t.TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Mapping
 
 logger = logging.getLogger(__name__)
 
@@ -424,6 +425,57 @@ class ClassicWorkspaceBuilder:
         except ObjectDoesNotExist:
             return False
         return True
+
+    def _bulk_set_options(
+        self,
+        items: Mapping[str, int | str | bool],
+        *,
+        target: str | None,
+        scope_flag: str,
+    ) -> None:
+        """Apply ``set-option`` for each (key, value) pair.
+
+        Mirrors :meth:`libtmux.options.OptionsMixin.set_option`'s
+        ``True/False -> "on"/"off"`` convention so behaviour matches a
+        plain loop of ``set_option`` calls. Errors propagate as the
+        same ``OptionError`` subclasses ``handle_option_error``
+        produces.
+
+        Currently issues one ``set-option`` round-trip per item. The
+        helper's API (mapping + scope flag + optional target) is
+        deliberately batch-shaped so the body can swap to a single
+        pipelined dispatch (e.g. ``Server.batch()``) once libtmux
+        exposes one, without touching the call sites in ``build`` and
+        ``iter_create_windows``.
+
+        Parameters
+        ----------
+        items : mapping
+            Option name -> value pairs.
+        target : str, optional
+            Target identifier (session_id / window_id) for ``-t``;
+            pass ``None`` for global options where ``-g`` already
+            names the scope.
+        scope_flag : str
+            ``"-s"``, ``"-g"``, or ``"-w"``. Selects the option scope.
+        """
+        if not items:
+            return
+        server = self.server
+        assert server is not None
+        for key, raw_val in items.items():
+            if raw_val is True:
+                val: int | str = "on"
+            elif raw_val is False:
+                val = "off"
+            else:
+                val = raw_val
+            if target is not None:
+                cmd = server.cmd("set-option", scope_flag, "-t", target, key, val)
+            else:
+                cmd = server.cmd("set-option", scope_flag, key, val)
+            if cmd.stderr:
+                handle_option_error(cmd.stderr[0])
 
     def build(self, session: Session | None = None, append: bool = False) -> None:
         """Build tmux workspace in session.

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 def _wait_for_pane_ready(
     pane: Pane,
     timeout: float = 2.0,
-    interval: float = 0.05,
+    interval: float = 0.01,
 ) -> bool:
     """Wait for pane shell to draw its prompt.
 

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -597,12 +597,18 @@ class ClassicWorkspaceBuilder:
                     self.on_build_event({"event": "before_script_done"})
 
         if "options" in self.session_config:
-            for option, value in self.session_config["options"].items():
-                self.session.set_option(option, value)
+            self._bulk_set_options(
+                self.session_config["options"],
+                target=self.session.session_id,
+                scope_flag="-s",
+            )
 
         if "global_options" in self.session_config:
-            for option, value in self.session_config["global_options"].items():
-                self.session.set_option(option, value, global_=True)
+            self._bulk_set_options(
+                self.session_config["global_options"],
+                target=None,
+                scope_flag="-g",
+            )
 
         if "environment" in self.session_config:
             for option, value in self.session_config["environment"].items():
@@ -762,8 +768,11 @@ class ClassicWorkspaceBuilder:
                 window_config["options"],
                 dict,
             ):
-                for key, val in window_config["options"].items():
-                    window.set_option(key, val)
+                self._bulk_set_options(
+                    window_config["options"],
+                    target=window.window_id,
+                    scope_flag="-w",
+                )
 
             if window_config.get("focus"):
                 window.select()
@@ -934,8 +943,11 @@ class ClassicWorkspaceBuilder:
             window_config["options_after"],
             dict,
         ):
-            for key, val in window_config["options_after"].items():
-                window.set_option(key, val)
+            self._bulk_set_options(
+                window_config["options_after"],
+                target=window.window_id,
+                scope_flag="-w",
+            )
 
     def find_current_attached_session(self) -> Session:
         """Return current attached session."""

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -360,6 +360,51 @@ def test_window_options_after(
         ), "Synchronized command did not execute properly"
 
 
+def test_bulk_set_options_propagates_unknown_option_error(
+    session: Session,
+) -> None:
+    """Bad options surface as ``OptionError``."""
+    workspace = {
+        "session_name": "bulk-set-options-bad",
+        "options": {"this-option-does-not-exist": "value"},
+        "windows": [{"window_name": "main", "panes": [{"shell_command": []}]}],
+    }
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    with pytest.raises(libtmux.exc.OptionError):
+        builder.build(session=session)
+
+
+def test_bulk_set_options_applies_session_window_and_options_after(
+    session: Session,
+) -> None:
+    """Session, window, and options_after loops all land via the helper."""
+    workspace = {
+        "session_name": "bulk-set-options-good",
+        "options": {"default-shell": "/bin/sh"},
+        "global_options": {"repeat-time": 491},
+        "windows": [
+            {
+                "window_name": "main",
+                "options": {"main-pane-height": 7},
+                "options_after": {"synchronize-panes": "on"},
+                "panes": [{"shell_command": []}, {"shell_command": []}],
+            },
+        ],
+    }
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    builder.build(session=session)
+
+    sess = builder.session
+    win = sess.active_window
+    default_shell = sess.show_option("default-shell")
+    assert isinstance(default_shell, str)
+    assert "/bin/sh" in default_shell
+    assert sess.show_option("repeat-time", global_=True) == 491
+    assert win.show_option("main-pane-height") == 7
+    sync = win.cmd("show-option", "-v", "synchronize-panes").stdout
+    assert sync == ["on"]
+
+
 def test_window_shell(
     session: Session,
 ) -> None:


### PR DESCRIPTION
## Summary

Three small, self-contained workspace-builder changes salvaged from a stalled experimental branch:

1. **`_wait_for_pane_ready` polling** tightened from 50ms to 10ms. Cuts ~2-3s off suite wall time (within run-to-run noise but consistent with commit body's claim).
2. **`_bulk_set_options` helper** added — a single, batch-shaped entry point for the four `set-option` loops the builder runs (session `options`, `global_options`, per-window `options`, `options_after`). Today the helper body is a plain loop, so this is a pure refactor; the call sites land on it so the body can later swap to a pipelined dispatch (e.g. a hypothetical `Server.batch()`) without touching the call sites.
3. **Call sites routed onto the helper** for the four `set-option` loops.

The helper exists today as forward-compat plumbing — there's no measurable perf gain from the refactor against current libtmux (0.56.0 ships only the subprocess path; batching pays off on engines libtmux hasn't released). The polling-tighten commit is the only commit that materially affects wall time.

## Why this PR exists

The bulk-options helper originated on a local-only experiment branch (`libtmux-protocol`) that pinned libtmux to a private worktree exposing a `Server.batch()` API. That experiment hasn't shipped upstream and may take time to land. Rather than let the call-site shape rot on a branch nobody can review, this PR salvages the shape against current libtmux. When `Server.batch()` (or equivalent) ships, the helper body becomes a one-line internal swap; the call sites stay as-is.

The polling-tighten commit was on the same experiment branch and is independent — it lands here because it shares context.

## Measured timing (3 runs salvage, 2 runs master)

```
Branch    Run  pytest   wall    notes
master    1    76.50s   71.73s
master    2    78.12s   70.79s
salvage   1    67.27s   62.92s
salvage   2    82.19s   74.66s  2 reruns (pre-existing tmux flake)
salvage   3    77.06s   69.41s
```

Median pytest is essentially tied (~77s). Median wall favors salvage by ~2s, matching the commit body's "~2.5s wall time" claim. One salvage run hit a tmux-state flake with 2 reruns — same flake potential exists on master, just didn't surface in these particular master runs.

## Per-commit breakdown

### `5cef952a` — `perf(workspace[wait]) tighten _wait_for_pane_ready polling interval to 10ms`

One-line change to the `interval` default in `_wait_for_pane_ready`. Tighter loop catches the early-readiness window (50-150ms tmux shell-ready latency) more reliably; the previous 50ms interval was missing the leading edge by definition.

### `6ccb0590` — `workspace(feat[builder]) add _bulk_set_options helper for set-option loops`

Adds `WorkspaceBuilder._bulk_set_options(items, *, target, scope_flag)`. Mirrors `OptionsMixin.set_option`'s `True/False -> "on"/"off"` normalisation so loop and helper paths produce identical tmux commands. Reuses libtmux's `handle_option_error` to preserve the `OptionError` subclasses callers already catch.

Body is a plain loop today. The API shape (mapping + scope flag + optional target) is deliberately batch-shaped so the body can swap to a pipelined dispatch when libtmux exposes one.

Adds two regression tests (`test_bulk_set_options_propagates_unknown_option_error`, `test_bulk_set_options_applies_session_window_and_options_after`).

### `9d4e4f3f` — `workspace(refactor[builder]) route set-option loops through _bulk_set_options`

Converts the four hot loops to call the helper. Pure refactor — same N round-trips per call site, same observable behaviour. The original commit framed this as a perf change; rewritten here as a refactor since `Server.batch()` isn't on libtmux 0.56.0 and the original commit body itself notes batching is "no-op cost on subprocess and imsg" anyway. Perf framing deferred to whenever libtmux ships a batching API.

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` — clean
- [x] `uv run ruff format .` — clean
- [x] `uv run mypy` — clean (124 source files)
- [x] `uv run py.test --reruns 0 -vvv` — 799 passed, 2 skipped (master had 797 + 2 new regression tests)
- [x] `just build-docs` — succeeds
- [x] Per-commit timing comparison vs master — see above