### PR TITLE
tests(perf[conftest]) Pin $SHELL=/bin/sh — 51% faster suite

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -56,6 +56,16 @@ _Notes on the upcoming release will go here._
   via `gp-furo-theme`, a Tailwind v4 respin of Furo, with
   `sphinx-vite-builder` handling theme-asset builds (#1037)
 
+### Development
+
+#### Test panes spawn `/bin/sh` instead of the developer's `$SHELL` (#1041)
+
+An autouse pytest fixture pins `$SHELL=/bin/sh` so test panes skip
+the contributor's interactive shell init. On systems with slow shell
+startup (zsh + oh-my-zsh, heavy bash profiles) this can roughly halve
+`uv run py.test` wall time; smaller gain on stripped-down shells. No
+effect on tmuxp's runtime behavior.
+
 
 ## tmuxp 1.67.0 (2026-03-08)
 

--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,20 @@ logger = logging.getLogger(__name__)
 USING_ZSH = "zsh" in os.getenv("SHELL", "")
 
 
+@pytest.fixture(autouse=True)
+def _pin_test_shell_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin ``$SHELL`` to ``/bin/sh`` for every test.
+
+    tmux falls back to ``$SHELL`` for new panes when ``default-shell`` is
+    unset, so pinning the env var here forces every test pane to spawn
+    ``/bin/sh`` instead of the contributor's interactive shell. Eliminates
+    rcfile init cost (zsh / oh-my-zsh / bash profile chains) and yields
+    deterministic prompt output that doesn't flake capture-pane assertions.
+    ``monkeypatch`` restores the prior value at teardown.
+    """
+    monkeypatch.setenv("SHELL", "/bin/sh")
+
+
 @pytest.fixture(autouse=USING_ZSH, scope="session")
 def zshrc(user_path: pathlib.Path) -> pathlib.Path | None:
     """Quiets ZSH default message.


### PR DESCRIPTION
## Summary

Add a 14-line autouse fixture to the root `conftest.py` that pins `$SHELL=/bin/sh` for every test. Drops `uv run py.test` wall time by **~51%** on this machine — from ~76s to ~36s — by bypassing the contributor's interactive shell init (zsh + oh-my-zsh + plugins, etc.) on every tmux pane the suite spawns.

## Why this works

tmux falls back to `$SHELL` for new panes when the `default-shell` option is unset. libtmux's bundled test `.tmux.conf` does not set `default-shell`, so every pane in tmuxp's test suite spawns the contributor's interactive `$SHELL` — typically `/bin/zsh` — and pays the full rcfile cost. With hundreds of pane spawns across the workspace/builder tests, that's the single largest line item in suite wall time.

`monkeypatch.setenv("SHELL", "/bin/sh")` in a function-scoped autouse fixture forces every test pane to spawn `/bin/sh` instead. Empty rcfiles, deterministic prompt, no plugin chains. `monkeypatch` restores the prior value at teardown so no global state leaks.

## Measured timing (this machine, `uv run py.test`)

```
master                ~76-78s pytest, ~71s wall
this branch (run 1)    37.01s pytest, 35.08s wall
this branch (run 2)    36.24s pytest, 34.29s wall
```

Both runs: 797 passed, 2 skipped, **zero reruns**. Master had occasional reruns on capture-pane assertions that depended on prompt timing; pinning the shell removes that source of flake along with the perf cost.

## Relationship to libtmux PR #662

This same fix exists upstream in [tmux-python/libtmux#662](https://github.com/tmux-python/libtmux/pull/662) (open since 2026-04-29), which pins `$SHELL=/bin/sh` in libtmux's own pytest plugin and reports a similar "~70s → ~32s" delta on tmuxp's suite. Once libtmux #662 merges and ships in a release tmuxp picks up, **this commit becomes redundant and can be reverted cleanly** (the autouse fixture would just be a no-op repeating what libtmux's plugin already does).

Landing this at the tmuxp conftest level lands the gain immediately rather than waiting on the upstream PR.

## What's not in this PR (deliberately)

- The `USING_ZSH` constant and `zshrc` autouse fixture become dead at runtime once `$SHELL` is always `/bin/sh` (no zsh first-run greeting to suppress, no rcfile chain to write a quieting `.zshrc` for). They're left in place to keep this PR's diff to the single load-bearing change. Cleanup belongs in a follow-up — easier to review and easier to revert if the perf claim ever needs to be questioned.

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` — clean
- [x] `uv run ruff format .` — clean
- [x] `uv run mypy` — clean (124 source files)
- [x] `uv run py.test` — 797 passed, 2 skipped, no reruns (both runs)
- [x] `just build-docs` — succeeds
- [x] Timing comparison vs master — see table above