### PR TITLE
Workspace(feat[runtime]): Add pane title and synchronization keys

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -56,10 +56,10 @@ required. See {ref}`top-level` for examples.
 
 #### New window keys: `synchronize`, `shell_command_after`, `clear` (#1047)
 
-`synchronize: before/after/true` mirrors keystrokes across a window's
-panes; `shell_command_after` runs commands in every pane after the
-window is built; `clear: true` clears each pane once its commands
-complete. See {ref}`top-level`.
+`synchronize` sets the final pane synchronization state while tmuxp keeps
+setup and post-build commands isolated per pane; `shell_command_after` runs
+commands in every pane after the window is built; `clear: true` clears each
+pane once its commands complete. See {ref}`top-level`.
 
 ## tmuxp 1.74.0 (2026-07-04)
 

--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,23 @@ $ tmuxp@next load yoursession
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### What's new
+
+#### Pane titles (#1047)
+
+Workspace configs can label panes natively: session-level
+`enable_pane_titles`, `pane_title_position`, and `pane_title_format`
+turn on tmux's pane border titles, and a pane-level `title` names
+individual panes — replacing the escape-sequence workaround previously
+required. See {ref}`top-level` for examples.
+
+#### New window keys: `synchronize`, `shell_command_after`, `clear` (#1047)
+
+`synchronize: before/after/true` mirrors keystrokes across a window's
+panes; `shell_command_after` runs commands in every pane after the
+window is built; `clear: true` clears each pane once its commands
+complete. See {ref}`top-level`.
+
 ## tmuxp 1.74.0 (2026-07-04)
 
 tmuxp 1.74.0 pairs a libtmux upgrade with a documentation overhaul. It bumps libtmux to 0.61.0 — hardening tmux 3.7 patch-line support — and teaches `tmuxp debug-info` to report the exact tmux patch release (`3.7a`/`3.7b`) instead of the numeric-normalized version. The docs also gain theme-aware inline diagrams and a concept-first rewrite that leads with what each feature is before its configuration.

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -515,9 +515,10 @@ Including `automatic-rename`, `default-shell`,
 
 ## Set window options after pane creation
 
-Apply window options after panes have been created. Useful for
-`synchronize-panes` option after executing individual commands in each
-pane during creation.
+Apply window options after panes have been created. When
+`synchronize-panes` appears in `options` or `options_after`, tmuxp keeps it
+disabled while sending configured commands and restores the requested final
+state after the window is ready.
 
 ````{tab} YAML
 ```{literalinclude} ../../examples/2-pane-synchronized.yaml
@@ -769,8 +770,8 @@ windows:
 
 ## Synchronize Panes Shorthand
 
-The `synchronize` window key provides a shorthand for enabling
-`synchronize-panes` without spelling out tmux options directly:
+The `synchronize` window key provides a shorthand for the final
+`synchronize-panes` state without spelling out tmux options directly:
 
 ````{tab} YAML
 ```{literalinclude} ../../examples/synchronize-shorthand.yaml

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -767,6 +767,29 @@ windows:
 [poetry]: https://python-poetry.org/
 [uv]: https://github.com/astral-sh/uv
 
+## Synchronize Panes Shorthand
+
+The `synchronize` window key provides a shorthand for enabling
+`synchronize-panes` without spelling out tmux options directly:
+
+````{tab} YAML
+```{literalinclude} ../../examples/synchronize-shorthand.yaml
+:language: yaml
+
+```
+````
+
+## Pane Titles
+
+Pane title keys turn on tmux pane border titles and label individual panes:
+
+````{tab} YAML
+```{literalinclude} ../../examples/pane-titles.yaml
+:language: yaml
+
+```
+````
+
 ## Kung fu
 
 :::{note}

--- a/docs/configuration/top-level.md
+++ b/docs/configuration/top-level.md
@@ -86,8 +86,10 @@ default label. Use a single space (`title: " "`) to visually blank one.
 
 ## synchronize
 
-Window-level shorthand for setting `synchronize-panes`. It accepts
-`before`, `after`, or `true`:
+Window-level shorthand for the final `synchronize-panes` state. tmuxp keeps
+pane synchronization disabled while it builds panes and sends configured
+commands, then restores the requested synchronized state after the window is
+ready.
 
 ```yaml
 session_name: sync-demo
@@ -105,9 +107,10 @@ windows:
 
 | Value | Behavior |
 |-------|----------|
-| `before` | Enable `synchronize-panes` before sending pane commands. |
-| `after` | Enable `synchronize-panes` after sending pane commands. |
-| `true` | Same as `before`. |
+| `after` | Synchronize panes after tmuxp finishes building the window. |
+| `before` | Compatibility alias for the same final synchronized state. |
+| `true` | Compatibility alias for the same final synchronized state. |
+| `false` | Force the final window state to unsynchronized. |
 
 ## shell_command_after
 
@@ -125,8 +128,9 @@ windows:
       - ./start-worker.sh
 ```
 
-`shell_command_after` runs before `options_after`, so `synchronize: after` does
-not duplicate the commands across synchronized panes.
+tmuxp keeps `synchronize-panes` disabled while `shell_command_after` runs, then
+restores the final synchronized state afterward. This prevents tmux from
+duplicating post-build commands across panes.
 
 Entries accept the same command mappings as `shell_command` — `enter`,
 `sleep_before`, and `sleep_after` apply per command (sleeps run once per

--- a/docs/configuration/top-level.md
+++ b/docs/configuration/top-level.md
@@ -123,6 +123,18 @@ windows:
 `shell_command_after` runs before `options_after`, so `synchronize: after` does
 not duplicate the commands across synchronized panes.
 
+Entries accept the same command mappings as `shell_command` — `enter`,
+`sleep_before`, and `sleep_after` apply per command (sleeps run once per
+command, before and after it is sent to every pane):
+
+```yaml
+shell_command_after:
+  - cmd: ./healthcheck.sh
+    sleep_before: 2
+  - cmd: tail -f app.log
+    enter: false
+```
+
 ## clear
 
 Window-level boolean. When `true`, sends `clear` to every pane after all

--- a/docs/configuration/top-level.md
+++ b/docs/configuration/top-level.md
@@ -49,3 +49,91 @@ classic builder.
 ```{seealso}
 {ref}`workspace-builders`
 ```
+
+## Pane Titles
+
+Enable pane border titles to display labels on each pane:
+
+```yaml
+session_name: myproject
+enable_pane_titles: true
+pane_title_position: top
+pane_title_format: "#{pane_index}: #{pane_title}"
+windows:
+  - window_name: dev
+    panes:
+      - title: editor
+        shell_command:
+          - vim
+      - title: tests
+        shell_command:
+          - uv run pytest --watch
+      - shell_command:
+          - git status
+```
+
+| Key | Level | Description |
+|-----|-------|-------------|
+| `enable_pane_titles` | session | Enable pane border titles (`true` or `false`). |
+| `pane_title_position` | session | Position of the title bar (`top`, `bottom`, or `off`). |
+| `pane_title_format` | session | Format string using tmux variables. |
+| `title` | pane | Title text for an individual pane. |
+
+## synchronize
+
+Window-level shorthand for setting `synchronize-panes`. It accepts
+`before`, `after`, or `true`:
+
+```yaml
+session_name: sync-demo
+windows:
+  - window_name: synced
+    synchronize: after
+    panes:
+      - echo pane0
+      - echo pane1
+  - window_name: not-synced
+    panes:
+      - echo pane0
+      - echo pane1
+```
+
+| Value | Behavior |
+|-------|----------|
+| `before` | Enable `synchronize-panes` before sending pane commands. |
+| `after` | Enable `synchronize-panes` after sending pane commands. |
+| `true` | Same as `before`. |
+
+## shell_command_after
+
+Window-level commands sent to every pane after all panes have been created and
+their individual commands executed:
+
+```yaml
+session_name: myproject
+windows:
+  - window_name: servers
+    shell_command_after:
+      - echo "All panes ready"
+    panes:
+      - ./start-api.sh
+      - ./start-worker.sh
+```
+
+`shell_command_after` runs before `options_after`, so `synchronize: after` does
+not duplicate the commands across synchronized panes.
+
+## clear
+
+Window-level boolean. When `true`, sends `clear` to every pane after all
+commands, including `shell_command_after`, have completed:
+
+```yaml
+session_name: myproject
+windows:
+  - window_name: dev
+    clear: true
+    panes:
+      - cd src
+      - cd tests
+```

--- a/docs/configuration/top-level.md
+++ b/docs/configuration/top-level.md
@@ -79,6 +79,11 @@ windows:
 | `pane_title_format` | session | Format string using tmux variables. |
 | `title` | pane | Title text for an individual pane. |
 
+```{note}
+tmux ignores empty pane titles — `title: ""` logs a warning and keeps the
+default label. Use a single space (`title: " "`) to visually blank one.
+```
+
 ## synchronize
 
 Window-level shorthand for setting `synchronize-panes`. It accepts

--- a/examples/pane-titles.yaml
+++ b/examples/pane-titles.yaml
@@ -1,0 +1,15 @@
+session_name: pane titles
+enable_pane_titles: true
+pane_title_position: top
+pane_title_format: "#{pane_index}: #{pane_title}"
+windows:
+  - window_name: titled
+    panes:
+      - title: editor
+        shell_command:
+          - echo pane0
+      - title: runner
+        shell_command:
+          - echo pane1
+      - shell_command:
+          - echo pane2

--- a/examples/synchronize-shorthand.yaml
+++ b/examples/synchronize-shorthand.yaml
@@ -1,0 +1,16 @@
+session_name: synchronize shorthand
+windows:
+  - window_name: synced-before
+    synchronize: before
+    panes:
+      - echo 0
+      - echo 1
+  - window_name: synced-after
+    synchronize: after
+    panes:
+      - echo 0
+      - echo 1
+  - window_name: not-synced
+    panes:
+      - echo 0
+      - echo 1

--- a/examples/synchronize-shorthand.yaml
+++ b/examples/synchronize-shorthand.yaml
@@ -1,16 +1,17 @@
 session_name: synchronize shorthand
 windows:
-  - window_name: synced-before
-    synchronize: before
-    panes:
-      - echo 0
-      - echo 1
   - window_name: synced-after
     synchronize: after
     panes:
       - echo 0
       - echo 1
+  - window_name: synced-compat-before
+    synchronize: before
+    panes:
+      - echo 0
+      - echo 1
   - window_name: not-synced
+    synchronize: false
     panes:
       - echo 0
       - echo 1

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -881,17 +881,19 @@ class ClassicWorkspaceBuilder:
         window_config : dict
             config section for window
         """
+        suppress = window_config.get("suppress_history", True)
+
         if "shell_command_after" in window_config and isinstance(
             window_config["shell_command_after"],
             dict,
         ):
             for cmd in window_config["shell_command_after"].get("shell_command", []):
                 for pane in window.panes:
-                    pane.send_keys(cmd["cmd"])
+                    pane.send_keys(cmd["cmd"], suppress_history=suppress)
 
         if window_config.get("clear"):
             for pane in window.panes:
-                pane.send_keys("clear", enter=True)
+                pane.send_keys("clear", enter=True, suppress_history=suppress)
 
         # Keep options_after last. synchronize-panes mirrors send-keys to every
         # pane, so enabling it before the fan-out above duplicates commands.

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -29,6 +29,12 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+SYNCHRONIZE_PANES_OPTION = "synchronize-panes"
+SYNCHRONIZE_PANES_FINAL_OPTION = "_synchronize_panes"
+SYNCHRONIZE_PANES_FORCED_OFF_OPTION = "_synchronize_panes_forced_off"
+SYNCHRONIZE_PANES_RESTORE_OPTION = "_synchronize_panes_restore"
+_MISSING = object()
+
 
 def _wait_for_pane_ready(
     pane: Pane,
@@ -87,6 +93,62 @@ def _wait_for_pane_ready(
         extra={"tmux_pane": str(pane.pane_id)},
     )
     return False
+
+
+def _get_window_option_value(
+    window_config: dict[str, t.Any],
+    section: str,
+    option: str,
+) -> t.Any:
+    """Return a window option value or ``_MISSING``.
+
+    Examples
+    --------
+    >>> cfg = {"options": {"synchronize-panes": "on"}}
+    >>> _get_window_option_value(cfg, "options", "synchronize-panes")
+    'on'
+    >>> _get_window_option_value(cfg, "options_after", "synchronize-panes") is _MISSING
+    True
+    """
+    options = window_config.get(section)
+    if isinstance(options, dict) and option in options:
+        return options[option]
+    return _MISSING
+
+
+def _get_final_synchronize_panes(window_config: dict[str, t.Any]) -> t.Any:
+    """Return the final configured ``synchronize-panes`` value.
+
+    ``options_after`` wins because it is the final tmux option bucket.
+
+    Examples
+    --------
+    >>> cfg = {
+    ...     "options": {"synchronize-panes": "off"},
+    ...     "_synchronize_panes": True,
+    ...     "options_after": {"synchronize-panes": "on"},
+    ... }
+    >>> _get_final_synchronize_panes(cfg)
+    'on'
+    >>> _get_final_synchronize_panes({}) is _MISSING
+    True
+    """
+    final_sync = _get_window_option_value(
+        window_config,
+        "options",
+        SYNCHRONIZE_PANES_OPTION,
+    )
+    if SYNCHRONIZE_PANES_FINAL_OPTION in window_config:
+        final_sync = window_config[SYNCHRONIZE_PANES_FINAL_OPTION]
+
+    after_sync = _get_window_option_value(
+        window_config,
+        "options_after",
+        SYNCHRONIZE_PANES_OPTION,
+    )
+    if after_sync is not _MISSING:
+        final_sync = after_sync
+    return final_sync
 
 
 COLUMNS_FALLBACK = 80
@@ -583,6 +645,8 @@ class ClassicWorkspaceBuilder:
             for plugin in self.plugins:
                 plugin.on_window_create(window)
 
+            self.prepare_window_synchronize_panes(window, window_config)
+
             focus_pane = None
             for pane, pane_config in self.iter_create_panes(window, window_config):
                 assert isinstance(pane, Pane)
@@ -711,12 +775,85 @@ class ClassicWorkspaceBuilder:
                 dict,
             ):
                 for key, val in window_config["options"].items():
+                    if key == SYNCHRONIZE_PANES_OPTION:
+                        continue
                     window.set_option(key, val)
 
             if window_config.get("focus"):
                 window.select()
 
             yield window, window_config
+
+    def prepare_window_synchronize_panes(
+        self,
+        window: Window,
+        window_config: dict[str, t.Any],
+    ) -> None:
+        """Disable tmux pane synchronization while tmuxp sends setup keys.
+
+        Examples
+        --------
+        >>> cfg = {"_synchronize_panes": True}
+        >>> builder = WorkspaceBuilder(
+        ...     session_config={"session_name": session.name, "windows": []},
+        ...     server=session.server,
+        ... )
+        >>> scratch = session.new_window(window_name="sync-prepare")
+        >>> builder.prepare_window_synchronize_panes(scratch, cfg)
+        >>> scratch.show_option("synchronize-panes")
+        False
+        >>> builder.restore_window_synchronize_panes(scratch, cfg)
+        >>> scratch.show_option("synchronize-panes")
+        True
+        >>> _ = scratch.kill()
+        """
+        final_sync = _get_final_synchronize_panes(window_config)
+        local_sync = window.show_option(SYNCHRONIZE_PANES_OPTION)
+        effective_sync = window.show_option(
+            SYNCHRONIZE_PANES_OPTION,
+            include_inherited=True,
+        )
+
+        if final_sync is not _MISSING or effective_sync is True:
+            if final_sync is _MISSING:
+                window_config[SYNCHRONIZE_PANES_RESTORE_OPTION] = local_sync
+            window.set_option(SYNCHRONIZE_PANES_OPTION, False)
+            window_config[SYNCHRONIZE_PANES_FORCED_OFF_OPTION] = True
+
+    def restore_window_synchronize_panes(
+        self,
+        window: Window,
+        window_config: dict[str, t.Any],
+    ) -> None:
+        """Restore the configured final tmux pane synchronization state.
+
+        Examples
+        --------
+        >>> cfg = {"_synchronize_panes": False}
+        >>> builder = WorkspaceBuilder(
+        ...     session_config={"session_name": session.name, "windows": []},
+        ...     server=session.server,
+        ... )
+        >>> scratch = session.new_window(window_name="sync-restore")
+        >>> builder.restore_window_synchronize_panes(scratch, cfg)
+        >>> scratch.show_option("synchronize-panes")
+        False
+        >>> _ = scratch.kill()
+        """
+        final_sync = _get_final_synchronize_panes(window_config)
+        if final_sync is _MISSING:
+            if window_config.get(SYNCHRONIZE_PANES_FORCED_OFF_OPTION):
+                restore_sync = window_config.get(
+                    SYNCHRONIZE_PANES_RESTORE_OPTION,
+                    _MISSING,
+                )
+                if restore_sync is _MISSING or restore_sync is None:
+                    window.unset_option(SYNCHRONIZE_PANES_OPTION, ignore_errors=True)
+                else:
+                    window.set_option(SYNCHRONIZE_PANES_OPTION, restore_sync)
+            return
+
+        window.set_option(SYNCHRONIZE_PANES_OPTION, final_sync)
 
     def iter_create_panes(
         self,
@@ -891,43 +1028,44 @@ class ClassicWorkspaceBuilder:
         """
         suppress = window_config.get("suppress_history", True)
 
-        # With synchronize-panes already on (synchronize: before/true or an
-        # explicit option), tmux mirrors each send to every pane — send to
-        # one pane and let tmux broadcast.
-        fanout_panes = (
-            window.panes[:1]
-            if window.show_option("synchronize-panes") is True
-            else window.panes
-        )
+        try:
+            if "shell_command_after" in window_config and isinstance(
+                window_config["shell_command_after"],
+                dict,
+            ):
+                for cmd in window_config["shell_command_after"].get(
+                    "shell_command",
+                    [],
+                ):
+                    enter = cmd.get("enter", True)
+                    sleep_before = cmd.get("sleep_before")
+                    sleep_after = cmd.get("sleep_after")
+                    # Sleeps apply once per command wave, not once per pane.
+                    if sleep_before is not None:
+                        time.sleep(sleep_before)
+                    for pane in window.panes:
+                        pane.send_keys(
+                            cmd["cmd"],
+                            suppress_history=suppress,
+                            enter=enter,
+                        )
+                    if sleep_after is not None:
+                        time.sleep(sleep_after)
 
-        if "shell_command_after" in window_config and isinstance(
-            window_config["shell_command_after"],
-            dict,
-        ):
-            for cmd in window_config["shell_command_after"].get("shell_command", []):
-                enter = cmd.get("enter", True)
-                sleep_before = cmd.get("sleep_before")
-                sleep_after = cmd.get("sleep_after")
-                # Sleeps apply once per command wave, not once per pane.
-                if sleep_before is not None:
-                    time.sleep(sleep_before)
-                for pane in fanout_panes:
-                    pane.send_keys(cmd["cmd"], suppress_history=suppress, enter=enter)
-                if sleep_after is not None:
-                    time.sleep(sleep_after)
+            if window_config.get("clear"):
+                for pane in window.panes:
+                    pane.send_keys("clear", enter=True, suppress_history=suppress)
 
-        if window_config.get("clear"):
-            for pane in fanout_panes:
-                pane.send_keys("clear", enter=True, suppress_history=suppress)
-
-        # Keep options_after last. synchronize-panes mirrors send-keys to every
-        # pane, so enabling it before the fan-out above duplicates commands.
-        if "options_after" in window_config and isinstance(
-            window_config["options_after"],
-            dict,
-        ):
-            for key, val in window_config["options_after"].items():
-                window.set_option(key, val)
+            if "options_after" in window_config and isinstance(
+                window_config["options_after"],
+                dict,
+            ):
+                for key, val in window_config["options_after"].items():
+                    if key == SYNCHRONIZE_PANES_OPTION:
+                        continue
+                    window.set_option(key, val)
+        finally:
+            self.restore_window_synchronize_panes(window, window_config)
 
     def find_current_attached_session(self) -> Session:
         """Return current attached session."""

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -888,8 +888,16 @@ class ClassicWorkspaceBuilder:
             dict,
         ):
             for cmd in window_config["shell_command_after"].get("shell_command", []):
+                enter = cmd.get("enter", True)
+                sleep_before = cmd.get("sleep_before")
+                sleep_after = cmd.get("sleep_after")
+                # Sleeps apply once per command wave, not once per pane.
+                if sleep_before is not None:
+                    time.sleep(sleep_before)
                 for pane in window.panes:
-                    pane.send_keys(cmd["cmd"], suppress_history=suppress)
+                    pane.send_keys(cmd["cmd"], suppress_history=suppress, enter=enter)
+                if sleep_after is not None:
+                    time.sleep(sleep_after)
 
         if window_config.get("clear"):
             for pane in window.panes:

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -639,7 +639,11 @@ class ClassicWorkspaceBuilder:
             },
         )
 
-        for window, window_config in self.iter_create_windows(session, append):
+        for window, window_config in self.iter_create_windows(
+            session,
+            append,
+            defer_synchronize_panes=True,
+        ):
             assert isinstance(window, Window)
 
             for plugin in self.plugins:
@@ -682,6 +686,7 @@ class ClassicWorkspaceBuilder:
         self,
         session: Session,
         append: bool = False,
+        defer_synchronize_panes: bool = False,
     ) -> Iterator[t.Any]:
         """Return :class:`libtmux.Window` iterating through session config dict.
 
@@ -696,6 +701,9 @@ class ClassicWorkspaceBuilder:
             session to create windows in
         append : bool
             append windows in current active session
+        defer_synchronize_panes : bool
+            defer ``synchronize-panes`` until the high-level build can restore
+            it after setup commands run
 
         Returns
         -------
@@ -775,7 +783,7 @@ class ClassicWorkspaceBuilder:
                 dict,
             ):
                 for key, val in window_config["options"].items():
-                    if key == SYNCHRONIZE_PANES_OPTION:
+                    if defer_synchronize_panes and key == SYNCHRONIZE_PANES_OPTION:
                         continue
                     window.set_option(key, val)
 

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -116,41 +116,6 @@ def _get_window_option_value(
     return _MISSING
 
 
-def _get_final_synchronize_panes(window_config: dict[str, t.Any]) -> t.Any:
-    """Return the final configured ``synchronize-panes`` value.
-
-    ``options_after`` wins because it is the final tmux option bucket.
-
-    Examples
-    --------
-    >>> cfg = {
-    ...     "options": {"synchronize-panes": "off"},
-    ...     "_synchronize_panes": True,
-    ...     "options_after": {"synchronize-panes": "on"},
-    ... }
-    >>> _get_final_synchronize_panes(cfg)
-    'on'
-    >>> _get_final_synchronize_panes({}) is _MISSING
-    True
-    """
-    final_sync = _get_window_option_value(
-        window_config,
-        "options",
-        SYNCHRONIZE_PANES_OPTION,
-    )
-    if SYNCHRONIZE_PANES_FINAL_OPTION in window_config:
-        final_sync = window_config[SYNCHRONIZE_PANES_FINAL_OPTION]
-
-    after_sync = _get_window_option_value(
-        window_config,
-        "options_after",
-        SYNCHRONIZE_PANES_OPTION,
-    )
-    if after_sync is not _MISSING:
-        final_sync = after_sync
-    return final_sync
-
-
 COLUMNS_FALLBACK = 80
 
 
@@ -639,12 +604,14 @@ class ClassicWorkspaceBuilder:
             },
         )
 
-        for window, window_config in self.iter_create_windows(
-            session,
-            append,
-            defer_synchronize_panes=True,
-        ):
+        for window, window_config in self.iter_create_windows(session, append):
             assert isinstance(window, Window)
+
+            if SYNCHRONIZE_PANES_FINAL_OPTION in window_config:
+                window.set_option(
+                    SYNCHRONIZE_PANES_OPTION,
+                    window_config[SYNCHRONIZE_PANES_FINAL_OPTION],
+                )
 
             for plugin in self.plugins:
                 plugin.on_window_create(window)
@@ -686,7 +653,6 @@ class ClassicWorkspaceBuilder:
         self,
         session: Session,
         append: bool = False,
-        defer_synchronize_panes: bool = False,
     ) -> Iterator[t.Any]:
         """Return :class:`libtmux.Window` iterating through session config dict.
 
@@ -701,9 +667,6 @@ class ClassicWorkspaceBuilder:
             session to create windows in
         append : bool
             append windows in current active session
-        defer_synchronize_panes : bool
-            defer ``synchronize-panes`` until the high-level build can restore
-            it after setup commands run
 
         Returns
         -------
@@ -783,8 +746,6 @@ class ClassicWorkspaceBuilder:
                 dict,
             ):
                 for key, val in window_config["options"].items():
-                    if defer_synchronize_panes and key == SYNCHRONIZE_PANES_OPTION:
-                        continue
                     window.set_option(key, val)
 
             if window_config.get("focus"):
@@ -801,12 +762,13 @@ class ClassicWorkspaceBuilder:
 
         Examples
         --------
-        >>> cfg = {"_synchronize_panes": True}
+        >>> cfg = {}
         >>> builder = WorkspaceBuilder(
         ...     session_config={"session_name": session.name, "windows": []},
         ...     server=session.server,
         ... )
         >>> scratch = session.new_window(window_name="sync-prepare")
+        >>> _ = scratch.set_option("synchronize-panes", True)
         >>> builder.prepare_window_synchronize_panes(scratch, cfg)
         >>> scratch.show_option("synchronize-panes")
         False
@@ -815,16 +777,14 @@ class ClassicWorkspaceBuilder:
         True
         >>> _ = scratch.kill()
         """
-        final_sync = _get_final_synchronize_panes(window_config)
         local_sync = window.show_option(SYNCHRONIZE_PANES_OPTION)
         effective_sync = window.show_option(
             SYNCHRONIZE_PANES_OPTION,
             include_inherited=True,
         )
 
-        if final_sync is not _MISSING or effective_sync is True:
-            if final_sync is _MISSING:
-                window_config[SYNCHRONIZE_PANES_RESTORE_OPTION] = local_sync
+        if effective_sync is True:
+            window_config[SYNCHRONIZE_PANES_RESTORE_OPTION] = local_sync
             window.set_option(SYNCHRONIZE_PANES_OPTION, False)
             window_config[SYNCHRONIZE_PANES_FORCED_OFF_OPTION] = True
 
@@ -837,31 +797,38 @@ class ClassicWorkspaceBuilder:
 
         Examples
         --------
-        >>> cfg = {"_synchronize_panes": False}
+        >>> cfg = {"options_after": {"synchronize-panes": "off"}}
         >>> builder = WorkspaceBuilder(
         ...     session_config={"session_name": session.name, "windows": []},
         ...     server=session.server,
         ... )
         >>> scratch = session.new_window(window_name="sync-restore")
+        >>> _ = scratch.set_option("synchronize-panes", True)
         >>> builder.restore_window_synchronize_panes(scratch, cfg)
         >>> scratch.show_option("synchronize-panes")
         False
         >>> _ = scratch.kill()
         """
-        final_sync = _get_final_synchronize_panes(window_config)
-        if final_sync is _MISSING:
-            if window_config.get(SYNCHRONIZE_PANES_FORCED_OFF_OPTION):
-                restore_sync = window_config.get(
-                    SYNCHRONIZE_PANES_RESTORE_OPTION,
-                    _MISSING,
-                )
-                if restore_sync is _MISSING or restore_sync is None:
-                    window.unset_option(SYNCHRONIZE_PANES_OPTION, ignore_errors=True)
-                else:
-                    window.set_option(SYNCHRONIZE_PANES_OPTION, restore_sync)
+        after_sync = _get_window_option_value(
+            window_config,
+            "options_after",
+            SYNCHRONIZE_PANES_OPTION,
+        )
+        if after_sync is not _MISSING:
+            window.set_option(SYNCHRONIZE_PANES_OPTION, after_sync)
             return
 
-        window.set_option(SYNCHRONIZE_PANES_OPTION, final_sync)
+        if not window_config.get(SYNCHRONIZE_PANES_FORCED_OFF_OPTION):
+            return
+
+        restore_sync = window_config.get(
+            SYNCHRONIZE_PANES_RESTORE_OPTION,
+            _MISSING,
+        )
+        if restore_sync is _MISSING or restore_sync is None:
+            window.unset_option(SYNCHRONIZE_PANES_OPTION, ignore_errors=True)
+        else:
+            window.set_option(SYNCHRONIZE_PANES_OPTION, restore_sync)
 
     def iter_create_panes(
         self,

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -891,6 +891,15 @@ class ClassicWorkspaceBuilder:
         """
         suppress = window_config.get("suppress_history", True)
 
+        # With synchronize-panes already on (synchronize: before/true or an
+        # explicit option), tmux mirrors each send to every pane — send to
+        # one pane and let tmux broadcast.
+        fanout_panes = (
+            window.panes[:1]
+            if window.show_option("synchronize-panes") is True
+            else window.panes
+        )
+
         if "shell_command_after" in window_config and isinstance(
             window_config["shell_command_after"],
             dict,
@@ -902,13 +911,13 @@ class ClassicWorkspaceBuilder:
                 # Sleeps apply once per command wave, not once per pane.
                 if sleep_before is not None:
                     time.sleep(sleep_before)
-                for pane in window.panes:
+                for pane in fanout_panes:
                     pane.send_keys(cmd["cmd"], suppress_history=suppress, enter=enter)
                 if sleep_after is not None:
                     time.sleep(sleep_after)
 
         if window_config.get("clear"):
-            for pane in window.panes:
+            for pane in fanout_panes:
                 pane.send_keys("clear", enter=True, suppress_history=suppress)
 
         # Keep options_after last. synchronize-panes mirrors send-keys to every

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -9,6 +9,7 @@ import time
 import typing as t
 
 from libtmux._internal.query_list import ObjectDoesNotExist
+from libtmux.constants import OptionScope
 from libtmux.pane import Pane
 from libtmux.server import Server
 from libtmux.session import Session
@@ -32,6 +33,7 @@ logger = logging.getLogger(__name__)
 SYNCHRONIZE_PANES_OPTION = "synchronize-panes"
 SYNCHRONIZE_PANES_FINAL_OPTION = "_synchronize_panes"
 SYNCHRONIZE_PANES_FORCED_OFF_OPTION = "_synchronize_panes_forced_off"
+SYNCHRONIZE_PANES_PANE_RESTORE_OPTION = "_synchronize_panes_pane_restore"
 SYNCHRONIZE_PANES_RESTORE_OPTION = "_synchronize_panes_restore"
 _MISSING = object()
 
@@ -619,17 +621,24 @@ class ClassicWorkspaceBuilder:
             self.prepare_window_synchronize_panes(window, window_config)
 
             focus_pane = None
-            for pane, pane_config in self.iter_create_panes(window, window_config):
-                assert isinstance(pane, Pane)
-                pane = pane
+            try:
+                for pane, pane_config in self.iter_create_panes(window, window_config):
+                    assert isinstance(pane, Pane)
+                    pane = pane
 
-                if pane_config.get("focus"):
-                    focus_pane = pane
+                    if pane_config.get("focus"):
+                        focus_pane = pane
 
-            if window_config.get("focus"):
-                focus = window
+                if window_config.get("focus"):
+                    focus = window
 
-            self.config_after_window(window, window_config)
+                self.config_after_window(window, window_config)
+            finally:
+                self.restore_window_synchronize_panes(
+                    window,
+                    window_config,
+                    apply_options_after=False,
+                )
 
             for plugin in self.plugins:
                 plugin.after_window_finished(window)
@@ -763,7 +772,7 @@ class ClassicWorkspaceBuilder:
         Examples
         --------
         >>> cfg = {}
-        >>> builder = WorkspaceBuilder(
+        >>> builder = ClassicWorkspaceBuilder(
         ...     session_config={"session_name": session.name, "windows": []},
         ...     server=session.server,
         ... )
@@ -788,17 +797,38 @@ class ClassicWorkspaceBuilder:
             window.set_option(SYNCHRONIZE_PANES_OPTION, False)
             window_config[SYNCHRONIZE_PANES_FORCED_OFF_OPTION] = True
 
+        pane_restores = []
+        for pane in window.panes:
+            local_pane_sync = pane.show_option(
+                SYNCHRONIZE_PANES_OPTION,
+                scope=OptionScope.Pane,
+            )
+            if local_pane_sync is True:
+                pane_restores.append((pane, local_pane_sync))
+                pane.set_option(
+                    SYNCHRONIZE_PANES_OPTION,
+                    False,
+                    scope=OptionScope.Pane,
+                    ignore_errors=True,
+                )
+
+        if pane_restores:
+            window_config[SYNCHRONIZE_PANES_PANE_RESTORE_OPTION] = pane_restores
+            window_config[SYNCHRONIZE_PANES_FORCED_OFF_OPTION] = True
+
     def restore_window_synchronize_panes(
         self,
         window: Window,
         window_config: dict[str, t.Any],
+        *,
+        apply_options_after: bool = True,
     ) -> None:
         """Restore the configured final tmux pane synchronization state.
 
         Examples
         --------
         >>> cfg = {"options_after": {"synchronize-panes": "off"}}
-        >>> builder = WorkspaceBuilder(
+        >>> builder = ClassicWorkspaceBuilder(
         ...     session_config={"session_name": session.name, "windows": []},
         ...     server=session.server,
         ... )
@@ -809,26 +839,49 @@ class ClassicWorkspaceBuilder:
         False
         >>> _ = scratch.kill()
         """
-        after_sync = _get_window_option_value(
-            window_config,
-            "options_after",
-            SYNCHRONIZE_PANES_OPTION,
+        after_sync = _MISSING
+        if apply_options_after:
+            after_sync = _get_window_option_value(
+                window_config,
+                "options_after",
+                SYNCHRONIZE_PANES_OPTION,
+            )
+
+        pane_restores = window_config.pop(
+            SYNCHRONIZE_PANES_PANE_RESTORE_OPTION,
+            [],
         )
-        if after_sync is not _MISSING:
-            window.set_option(SYNCHRONIZE_PANES_OPTION, after_sync)
-            return
-
-        if not window_config.get(SYNCHRONIZE_PANES_FORCED_OFF_OPTION):
-            return
-
-        restore_sync = window_config.get(
+        forced_off = window_config.pop(SYNCHRONIZE_PANES_FORCED_OFF_OPTION, False)
+        restore_sync = window_config.pop(
             SYNCHRONIZE_PANES_RESTORE_OPTION,
             _MISSING,
         )
-        if restore_sync is _MISSING or restore_sync is None:
-            window.unset_option(SYNCHRONIZE_PANES_OPTION, ignore_errors=True)
-        else:
-            window.set_option(SYNCHRONIZE_PANES_OPTION, restore_sync)
+
+        if after_sync is not _MISSING:
+            window.set_option(SYNCHRONIZE_PANES_OPTION, t.cast(int | str, after_sync))
+        elif forced_off and restore_sync is not _MISSING:
+            if restore_sync is None:
+                window.unset_option(SYNCHRONIZE_PANES_OPTION, ignore_errors=True)
+            else:
+                window.set_option(
+                    SYNCHRONIZE_PANES_OPTION,
+                    t.cast(int | str, restore_sync),
+                )
+
+        for pane, restore_pane_sync in pane_restores:
+            if restore_pane_sync is _MISSING or restore_pane_sync is None:
+                pane.unset_option(
+                    SYNCHRONIZE_PANES_OPTION,
+                    scope=OptionScope.Pane,
+                    ignore_errors=True,
+                )
+            else:
+                pane.set_option(
+                    SYNCHRONIZE_PANES_OPTION,
+                    t.cast(int | str, restore_pane_sync),
+                    scope=OptionScope.Pane,
+                    ignore_errors=True,
+                )
 
     def iter_create_panes(
         self,

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -854,8 +854,16 @@ class ClassicWorkspaceBuilder:
                 if sleep_after is not None:
                     time.sleep(sleep_after)
 
-            if pane_config.get("title"):
-                pane.set_title(pane_config["title"])
+            title = pane_config.get("title")
+            if title:
+                pane.set_title(title)
+            elif title is not None:
+                # tmux discards `select-pane -T ""`; an empty pane title
+                # cannot be applied.
+                pane_log.warning(
+                    "tmux ignores empty pane titles; use a single space "
+                    "to blank the label",
+                )
 
             if pane_config.get("focus"):
                 assert pane.pane_id is not None

--- a/src/tmuxp/workspace/builder/classic.py
+++ b/src/tmuxp/workspace/builder/classic.py
@@ -854,6 +854,9 @@ class ClassicWorkspaceBuilder:
                 if sleep_after is not None:
                     time.sleep(sleep_after)
 
+            if pane_config.get("title"):
+                pane.set_title(pane_config["title"])
+
             if pane_config.get("focus"):
                 assert pane.pane_id is not None
                 window.select_pane(pane.pane_id)
@@ -878,6 +881,20 @@ class ClassicWorkspaceBuilder:
         window_config : dict
             config section for window
         """
+        if "shell_command_after" in window_config and isinstance(
+            window_config["shell_command_after"],
+            dict,
+        ):
+            for cmd in window_config["shell_command_after"].get("shell_command", []):
+                for pane in window.panes:
+                    pane.send_keys(cmd["cmd"])
+
+        if window_config.get("clear"):
+            for pane in window.panes:
+                pane.send_keys("clear", enter=True)
+
+        # Keep options_after last. synchronize-panes mirrors send-keys to every
+        # pane, so enabling it before the fan-out above duplicates commands.
         if "options_after" in window_config and isinstance(
             window_config["options_after"],
             dict,

--- a/src/tmuxp/workspace/loader.py
+++ b/src/tmuxp/workspace/loader.py
@@ -197,6 +197,9 @@ def expand(
                 "defaulting to 'top'",
                 position,
                 valid_positions,
+                extra={
+                    "tmux_session": str(workspace_dict.get("session_name") or ""),
+                },
             )
             position = "top"
         pane_title_format = workspace_dict.pop(

--- a/src/tmuxp/workspace/loader.py
+++ b/src/tmuxp/workspace/loader.py
@@ -139,6 +139,13 @@ def expand(
                     val = str(cwd / val)
             workspace_dict["options"][key] = val
 
+    if "synchronize" in workspace_dict:
+        sync = workspace_dict.pop("synchronize")
+        if sync is True or sync == "before":
+            workspace_dict.setdefault("options", {})["synchronize-panes"] = "on"
+        elif sync == "after":
+            workspace_dict.setdefault("options_after", {})["synchronize-panes"] = "on"
+
     # Any workspace section, session, window, pane that can contain the
     # 'shell_command' value
     if "start_directory" in workspace_dict:
@@ -175,6 +182,36 @@ def expand(
         shell_command_before = workspace_dict["shell_command_before"]
 
         workspace_dict["shell_command_before"] = expand_cmd(shell_command_before)
+
+    if "shell_command_after" in workspace_dict:
+        shell_command_after = workspace_dict["shell_command_after"]
+
+        workspace_dict["shell_command_after"] = expand_cmd(shell_command_after)
+
+    if workspace_dict.get("enable_pane_titles") and "windows" in workspace_dict:
+        valid_positions = {"top", "bottom", "off"}
+        position = workspace_dict.pop("pane_title_position", "top")
+        if position not in valid_positions:
+            logger.warning(
+                "invalid pane_title_position %r, expected one of %s; "
+                "defaulting to 'top'",
+                position,
+                valid_positions,
+            )
+            position = "top"
+        pane_title_format = workspace_dict.pop(
+            "pane_title_format",
+            "#{pane_index}: #{pane_title}",
+        )
+        workspace_dict.pop("enable_pane_titles")
+        for window in workspace_dict["windows"]:
+            window.setdefault("options", {})
+            window["options"].setdefault("pane-border-status", position)
+            window["options"].setdefault("pane-border-format", pane_title_format)
+    elif "enable_pane_titles" in workspace_dict:
+        workspace_dict.pop("enable_pane_titles")
+        workspace_dict.pop("pane_title_position", None)
+        workspace_dict.pop("pane_title_format", None)
 
     # recurse into window and pane workspace items
     if "windows" in workspace_dict:

--- a/src/tmuxp/workspace/loader.py
+++ b/src/tmuxp/workspace/loader.py
@@ -9,6 +9,8 @@ import typing as t
 
 logger = logging.getLogger(__name__)
 
+SYNCHRONIZE_PANES_FINAL_OPTION = "_synchronize_panes"
+
 
 def expandshell(value: str) -> str:
     """Resolve shell variables based on user's ``$HOME`` and ``env``.
@@ -141,10 +143,23 @@ def expand(
 
     if "synchronize" in workspace_dict:
         sync = workspace_dict.pop("synchronize")
-        if sync is True or sync == "before":
-            workspace_dict.setdefault("options", {})["synchronize-panes"] = "on"
-        elif sync == "after":
-            workspace_dict.setdefault("options_after", {})["synchronize-panes"] = "on"
+        if sync is True or sync in ["before", "after"]:
+            workspace_dict[SYNCHRONIZE_PANES_FINAL_OPTION] = True
+        elif sync is False:
+            workspace_dict[SYNCHRONIZE_PANES_FINAL_OPTION] = False
+        else:
+            session_name = workspace_dict.get("session_name")
+            if session_name is None and isinstance(parent, dict):
+                session_name = parent.get("session_name")
+            logger.warning(
+                "invalid synchronize value %r, expected true, false, "
+                "'before', or 'after'",
+                sync,
+                extra={
+                    "tmux_session": str(session_name or ""),
+                    "tmux_window": str(workspace_dict.get("window_name") or ""),
+                },
+            )
 
     # Any workspace section, session, window, pane that can contain the
     # 'shell_command' value

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -360,6 +360,217 @@ def test_window_options_after(
         ), "Synchronized command did not execute properly"
 
 
+class SynchronizeBuilderFixture(t.NamedTuple):
+    """Fixture for synchronize shorthand builder behavior."""
+
+    test_id: str
+    synchronize: bool | str
+    expected_synchronized: bool | None
+
+
+SYNCHRONIZE_BUILDER_FIXTURES: list[SynchronizeBuilderFixture] = [
+    SynchronizeBuilderFixture(
+        test_id="true",
+        synchronize=True,
+        expected_synchronized=True,
+    ),
+    SynchronizeBuilderFixture(
+        test_id="before",
+        synchronize="before",
+        expected_synchronized=True,
+    ),
+    SynchronizeBuilderFixture(
+        test_id="after",
+        synchronize="after",
+        expected_synchronized=True,
+    ),
+    SynchronizeBuilderFixture(
+        test_id="false",
+        synchronize=False,
+        expected_synchronized=None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(SynchronizeBuilderFixture._fields),
+    SYNCHRONIZE_BUILDER_FIXTURES,
+    ids=[fixture.test_id for fixture in SYNCHRONIZE_BUILDER_FIXTURES],
+)
+def test_synchronize_builder_options(
+    session: Session,
+    test_id: str,
+    synchronize: bool | str,
+    expected_synchronized: bool,
+) -> None:
+    """Synchronize shorthand sets synchronize-panes on the built window."""
+    workspace: dict[str, t.Any] = {
+        "session_name": f"sync-builder-{test_id}",
+        "windows": [
+            {
+                "window_name": "main",
+                "synchronize": synchronize,
+                "panes": ["echo pane0", "echo pane1"],
+            },
+        ],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    builder.build(session=session)
+
+    assert session.windows[0].show_option("synchronize-panes") is expected_synchronized
+
+
+def test_synchronize_after_runs_shell_command_after_once_per_pane(
+    session: Session,
+) -> None:
+    """synchronize: after does not mirror shell_command_after across panes."""
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        "windows": [
+            {
+                "window_name": "sync-after-cmds",
+                "synchronize": "after",
+                "shell_command_after": [
+                    "echo __SYNC_AF''TER__",
+                    "echo __SYNC_DO''NE__",
+                ],
+                "panes": ["echo pane0", "echo pane1"],
+            },
+        ],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    builder.build(session=session)
+
+    window = session.windows[0]
+    assert window.show_option("synchronize-panes") is True
+
+    def output_lines(pane: Pane, marker: str) -> int:
+        return sum(1 for line in pane.capture_pane() if line.strip() == marker)
+
+    for pane in window.panes:
+
+        def done(p: Pane = pane) -> bool:
+            return output_lines(p, "__SYNC_DONE__") >= 1
+
+        assert retry_until(done), f"Expected __SYNC_DONE__ in pane {pane.pane_id}"
+        count = output_lines(pane, "__SYNC_AFTER__")
+        assert count == 1, (
+            f"Pane {pane.pane_id} ran shell_command_after {count} times; "
+            "synchronize-panes was enabled before the fan-out"
+        )
+
+
+def test_pane_titles(
+    session: Session,
+) -> None:
+    """Pane title config sets pane-border options and pane titles."""
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        "enable_pane_titles": True,
+        "windows": [
+            {
+                "window_name": "titled",
+                "panes": [
+                    {"title": "editor", "shell_command": ["echo pane0"]},
+                    {"title": "runner", "shell_command": ["echo pane1"]},
+                    {"shell_command": ["echo pane2"]},
+                ],
+            },
+        ],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    builder.build(session=session)
+
+    window = session.windows[0]
+    assert window.show_option("pane-border-status") == "top"
+    assert window.show_option("pane-border-format") == "#{pane_index}: #{pane_title}"
+
+    panes = window.panes
+    assert len(panes) == 3
+
+    def check_title(pane: Pane, expected: str) -> bool:
+        pane.refresh()
+        return pane.pane_title == expected
+
+    assert retry_until(functools.partial(check_title, panes[0], "editor")), (
+        f"Expected title 'editor', got {panes[0].pane_title!r}"
+    )
+    assert retry_until(functools.partial(check_title, panes[1], "runner")), (
+        f"Expected title 'runner', got {panes[1].pane_title!r}"
+    )
+
+
+class ClearBuilderFixture(t.NamedTuple):
+    """Fixture for clear window behavior."""
+
+    test_id: str
+    clear: bool
+    marker_should_remain: bool
+
+
+CLEAR_BUILDER_FIXTURES: list[ClearBuilderFixture] = [
+    ClearBuilderFixture(
+        test_id="clear-true",
+        clear=True,
+        marker_should_remain=False,
+    ),
+    ClearBuilderFixture(
+        test_id="clear-false",
+        clear=False,
+        marker_should_remain=True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(ClearBuilderFixture._fields),
+    CLEAR_BUILDER_FIXTURES,
+    ids=[fixture.test_id for fixture in CLEAR_BUILDER_FIXTURES],
+)
+def test_clear_window(
+    session: Session,
+    test_id: str,
+    clear: bool,
+    marker_should_remain: bool,
+) -> None:
+    """Clear sends clear to panes only when enabled."""
+    marker = f"__{test_id.upper().replace('-', '_')}__"
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        "windows": [
+            {
+                "window_name": "clear-test",
+                "clear": clear,
+                "panes": [{"shell_command": [f"echo {marker}"]}],
+            },
+        ],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    builder.build(session=session)
+
+    pane = session.windows[0].panes[0]
+
+    def marker_visible() -> bool:
+        return marker in "\n".join(pane.capture_pane())
+
+    if marker_should_remain:
+        assert retry_until(marker_visible)
+    else:
+
+        def marker_cleared() -> bool:
+            return not marker_visible()
+
+        assert retry_until(marker_cleared, raises=False)
+
+
 def test_window_shell(
     session: Session,
 ) -> None:

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -13,6 +13,7 @@ import typing as t
 import libtmux
 import pytest
 from libtmux._internal.query_list import ObjectDoesNotExist
+from libtmux.constants import OptionScope
 from libtmux.exc import LibTmuxException
 from libtmux.pane import Pane
 from libtmux.session import Session
@@ -564,6 +565,9 @@ def test_synchronize_keeps_setup_commands_isolated(
     window_config.update(window_extra)
     workspace: dict[str, t.Any] = {
         "session_name": session.name,
+        # Force the readiness wait; AUTO only waits for zsh, which the test
+        # tmux server's default-shell isn't, making capture assertions racy.
+        "workspace_builder_options": {"pane_readiness": "always"},
         "windows": [window_config],
     }
     workspace = loader.expand(workspace)
@@ -591,6 +595,249 @@ def test_synchronize_keeps_setup_commands_isolated(
         window.show_option("synchronize-panes", include_inherited=True)
         is expected_effective_sync
     )
+
+
+class SyncSetupAbortFixture(t.NamedTuple):
+    """Fixture for synchronize-panes cleanup after pane setup aborts."""
+
+    test_id: str
+    window_extra: dict[str, t.Any]
+    global_synchronize: bool
+    plugin_synchronize: bool | None
+    expected_local_sync: bool | None
+    expected_effective_sync: bool
+
+
+SYNC_SETUP_ABORT_FIXTURES: list[SyncSetupAbortFixture] = [
+    SyncSetupAbortFixture(
+        test_id="sync_true",
+        window_extra={"synchronize": True},
+        global_synchronize=False,
+        plugin_synchronize=None,
+        expected_local_sync=True,
+        expected_effective_sync=True,
+    ),
+    SyncSetupAbortFixture(
+        test_id="raw_option_on",
+        window_extra={"options": {"synchronize-panes": "on"}},
+        global_synchronize=False,
+        plugin_synchronize=None,
+        expected_local_sync=True,
+        expected_effective_sync=True,
+    ),
+    SyncSetupAbortFixture(
+        test_id="inherits_global_on",
+        window_extra={},
+        global_synchronize=True,
+        plugin_synchronize=None,
+        expected_local_sync=None,
+        expected_effective_sync=True,
+    ),
+    SyncSetupAbortFixture(
+        test_id="options_after_off_keeps_inherited_global_on",
+        window_extra={"options_after": {"synchronize-panes": "off"}},
+        global_synchronize=True,
+        plugin_synchronize=None,
+        expected_local_sync=None,
+        expected_effective_sync=True,
+    ),
+    SyncSetupAbortFixture(
+        test_id="options_after_on_does_not_run_on_setup_abort",
+        window_extra={"options_after": {"synchronize-panes": "on"}},
+        global_synchronize=False,
+        plugin_synchronize=None,
+        expected_local_sync=None,
+        expected_effective_sync=False,
+    ),
+    SyncSetupAbortFixture(
+        test_id="plugin_on",
+        window_extra={},
+        global_synchronize=False,
+        plugin_synchronize=True,
+        expected_local_sync=True,
+        expected_effective_sync=True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(SyncSetupAbortFixture._fields),
+    SYNC_SETUP_ABORT_FIXTURES,
+    ids=[fixture.test_id for fixture in SYNC_SETUP_ABORT_FIXTURES],
+)
+def test_synchronize_restores_state_when_pane_setup_aborts(
+    session: Session,
+    test_id: str,
+    window_extra: dict[str, t.Any],
+    global_synchronize: bool,
+    plugin_synchronize: bool | None,
+    expected_local_sync: bool | None,
+    expected_effective_sync: bool,
+) -> None:
+    """Pane setup failures restore temporarily disabled synchronize-panes state."""
+
+    class SyncOnWindowCreatePlugin:
+        """Plugin that optionally sets the sync state before pane setup."""
+
+        def before_workspace_builder(self, session: Session) -> None:
+            """No-op workspace hook."""
+
+        def on_window_create(self, window: Window) -> None:
+            """Set the synchronized state before pane setup starts."""
+            if plugin_synchronize is not None:
+                window.set_option("synchronize-panes", plugin_synchronize)
+
+        def after_window_finished(self, window: Window) -> None:
+            """No-op window hook."""
+
+    try:
+        if global_synchronize:
+            session.server.cmd("set-window-option", "-g", "synchronize-panes", "on")
+
+        window_config: dict[str, t.Any] = {
+            "window_name": f"sync-abort-{test_id}",
+            # Invalid layout used to force a build abort. The "0000," hex
+            # prefix matters: a bare invalid name (no "hex," prefix) makes
+            # tmux 3.3/3.3a free an uninitialized `cause` pointer and crash
+            # the server (fixed upstream in 3.4); the prefix routes every
+            # tmux >= 3.2 to the clean "invalid layout" error instead.
+            "layout": "0000,not-a-layout",
+            "panes": [
+                "printf '__PANE0__\\n'",
+                "printf '__PANE1__\\n'",
+            ],
+        }
+        window_config.update(window_extra)
+        workspace: dict[str, t.Any] = {
+            "session_name": session.name,
+            "windows": [window_config],
+        }
+        workspace = loader.expand(workspace)
+
+        plugins: list[t.Any] = []
+        if plugin_synchronize is not None:
+            plugins.append(SyncOnWindowCreatePlugin())
+        builder = WorkspaceBuilder(
+            session_config=workspace,
+            server=session.server,
+            plugins=plugins,
+        )
+
+        # tmux 3.2/3.2a report "can't set layout"; 3.3+ report "invalid
+        # layout" for the same rejected layout — accept either.
+        with pytest.raises(LibTmuxException, match=r"invalid layout|can't set layout"):
+            builder.build(session=session)
+
+        window = session.windows[0]
+        assert window.show_option("synchronize-panes") is expected_local_sync
+        assert (
+            window.show_option("synchronize-panes", include_inherited=True)
+            is expected_effective_sync
+        )
+    finally:
+        session.server.cmd("set-window-option", "-gu", "synchronize-panes")
+
+
+class SyncPaneLocalPluginFixture(t.NamedTuple):
+    """Fixture for plugin-created pane-local synchronize-panes state."""
+
+    test_id: str
+    window_extra: dict[str, t.Any]
+    expected_window_sync: bool | None
+
+
+SYNC_PANE_LOCAL_PLUGIN_FIXTURES: list[SyncPaneLocalPluginFixture] = [
+    SyncPaneLocalPluginFixture(
+        test_id="window_option_on",
+        window_extra={"options": {"synchronize-panes": "on"}},
+        expected_window_sync=True,
+    ),
+    SyncPaneLocalPluginFixture(
+        test_id="synchronize_false",
+        window_extra={"synchronize": False},
+        expected_window_sync=False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(SyncPaneLocalPluginFixture._fields),
+    SYNC_PANE_LOCAL_PLUGIN_FIXTURES,
+    ids=[fixture.test_id for fixture in SYNC_PANE_LOCAL_PLUGIN_FIXTURES],
+)
+def test_synchronize_disables_plugin_pane_local_state_during_setup(
+    session: Session,
+    test_id: str,
+    window_extra: dict[str, t.Any],
+    expected_window_sync: bool | None,
+) -> None:
+    """Pane-local plugin sync state does not broadcast tmuxp setup commands."""
+
+    class PaneLocalSyncPlugin:
+        """Plugin that creates panes with pane-local sync before tmuxp setup."""
+
+        def before_workspace_builder(self, session: Session) -> None:
+            """No-op workspace hook."""
+
+        def on_window_create(self, window: Window) -> None:
+            """Create pane-local sync state before tmuxp sends setup keys."""
+            first = window.active_pane
+            assert isinstance(first, Pane)
+            second = first.split(attach=True)
+            assert isinstance(second, Pane)
+            first.set_option(
+                "synchronize-panes",
+                True,
+                scope=OptionScope.Pane,
+            )
+            second.set_option(
+                "synchronize-panes",
+                True,
+                scope=OptionScope.Pane,
+            )
+
+        def after_window_finished(self, window: Window) -> None:
+            """No-op window hook."""
+
+    window_config: dict[str, t.Any] = {
+        "window_name": f"sync-pane-local-{test_id}",
+        "panes": [
+            "printf '__PANE0__\\n'",
+            "printf '__PANE1__\\n'",
+        ],
+    }
+    window_config.update(window_extra)
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        # Force the readiness wait; AUTO only waits for zsh, which the test
+        # tmux server's default-shell isn't, making capture assertions racy.
+        "workspace_builder_options": {"pane_readiness": "always"},
+        "windows": [window_config],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(
+        session_config=workspace,
+        server=session.server,
+        plugins=[PaneLocalSyncPlugin()],
+    )
+    builder.build(session=session)
+
+    window = session.windows[0]
+    panes = window.panes
+
+    def output_lines(pane: Pane, marker: str) -> int:
+        return sum(1 for line in pane.capture_pane() if line.strip() == marker)
+
+    def setup_complete() -> bool:
+        return sum(output_lines(pane, "__PANE1__") for pane in panes) == 1
+
+    assert retry_until(setup_complete), "Expected plugin-pane setup to finish"
+    assert sum(output_lines(pane, "__PANE0__") for pane in panes) == 1
+    assert sum(output_lines(pane, "__PANE1__") for pane in panes) == 1
+    assert panes[0].show_option("synchronize-panes") is True
+    assert panes[1].show_option("synchronize-panes") is True
+    assert window.show_option("synchronize-panes") is expected_window_sync
 
 
 class SyncPluginOverrideFixture(t.NamedTuple):
@@ -671,6 +918,10 @@ def _build_synchronize_plugin_workspace(
     window_config.update(window_extra)
     workspace: dict[str, t.Any] = {
         "session_name": session.name,
+        # Force the pane-readiness wait so setup send-keys lands after the
+        # prompt is drawn. AUTO only waits for zsh, which the test tmux
+        # server's default-shell isn't, making the capture assertions racy.
+        "workspace_builder_options": {"pane_readiness": "always"},
         "windows": [window_config],
     }
     workspace = loader.expand(workspace)
@@ -2737,7 +2988,7 @@ def test_shell_command_after_honors_command_options(
         slept.append(seconds)
         original_sleep(0)
 
-    monkeypatch.setattr("tmuxp.workspace.builder.time.sleep", spy_sleep)
+    monkeypatch.setattr("tmuxp.workspace.builder.classic.time.sleep", spy_sleep)
 
     workspace: dict[str, t.Any] = {
         "session_name": session.name,

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -2231,3 +2231,119 @@ def test_builder_logs_window_and_pane_creation(
     assert len(cmd_logs) >= 1
 
     builder.session.kill()
+
+
+class AfterCommandOptionsFixture(t.NamedTuple):
+    """Fixture for per-command options in shell_command_after mappings."""
+
+    test_id: str
+    command: dict[str, t.Any]
+    expected_enter: bool
+    expected_sleeps: list[float]
+
+
+AFTER_COMMAND_OPTIONS_FIXTURES: list[AfterCommandOptionsFixture] = [
+    AfterCommandOptionsFixture(
+        test_id="enter_false_respected",
+        command={"cmd": "echo __AFTER_OPT__", "enter": False},
+        expected_enter=False,
+        expected_sleeps=[],
+    ),
+    AfterCommandOptionsFixture(
+        test_id="sleeps_once_per_wave",
+        command={
+            "cmd": "echo __AFTER_OPT__",
+            "sleep_before": 0.21,
+            "sleep_after": 0.31,
+        },
+        expected_enter=True,
+        expected_sleeps=[0.21, 0.31],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(AfterCommandOptionsFixture._fields),
+    AFTER_COMMAND_OPTIONS_FIXTURES,
+    ids=[fixture.test_id for fixture in AFTER_COMMAND_OPTIONS_FIXTURES],
+)
+def test_shell_command_after_honors_command_options(
+    session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    test_id: str,
+    command: dict[str, t.Any],
+    expected_enter: bool,
+    expected_sleeps: list[float],
+) -> None:
+    """shell_command_after mappings keep their enter and sleep options.
+
+    The pane command loop honors per-command enter/sleep_before/
+    sleep_after; the post-build fan-out accepts the same mapping syntax
+    and must behave the same. Sleeps apply once per command wave, not
+    once per pane.
+    """
+    sent: list[tuple[str | None, bool | None]] = []
+    original_send_keys = Pane.send_keys
+
+    def spy_send_keys(
+        self: Pane,
+        cmd: str | None = None,
+        enter: bool | None = True,
+        suppress_history: bool | None = False,
+        literal: bool | None = False,
+        reset: bool | None = None,
+        copy_mode_cmd: str | None = None,
+        repeat: int | None = None,
+        expand_formats: bool | None = None,
+        hex_keys: bool | None = None,
+        target_client: str | None = None,
+        key_name: bool | None = None,
+    ) -> None:
+        sent.append((cmd, enter))
+        original_send_keys(
+            self,
+            cmd=cmd,
+            enter=enter,
+            suppress_history=suppress_history,
+            literal=literal,
+            reset=reset,
+            copy_mode_cmd=copy_mode_cmd,
+            repeat=repeat,
+            expand_formats=expand_formats,
+            hex_keys=hex_keys,
+            target_client=target_client,
+            key_name=key_name,
+        )
+
+    monkeypatch.setattr(Pane, "send_keys", spy_send_keys)
+
+    slept: list[float] = []
+    original_sleep = time.sleep
+
+    def spy_sleep(seconds: float) -> None:
+        slept.append(seconds)
+        original_sleep(0)
+
+    monkeypatch.setattr("tmuxp.workspace.builder.time.sleep", spy_sleep)
+
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        "windows": [
+            {
+                "window_name": f"after-options-{test_id}",
+                "shell_command_after": [command],
+                "panes": ["echo pane0", "echo pane1"],
+            },
+        ],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    builder.build(session=session)
+
+    after_sends = [entry for entry in sent if entry[0] == "echo __AFTER_OPT__"]
+    assert len(after_sends) == 2, "after-command should reach both panes"
+    assert all(enter is expected_enter for _, enter in after_sends)
+
+    option_sleeps = [s for s in slept if s in (0.21, 0.31)]
+    assert sorted(option_sleeps) == sorted(expected_sleeps)

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -571,6 +571,98 @@ def test_clear_window(
         assert retry_until(marker_cleared, raises=False)
 
 
+class PostBuildSuppressHistoryFixture(t.NamedTuple):
+    """Fixture for post-build suppress_history behavior."""
+
+    test_id: str
+    suppress_history: bool | None
+    expected_suppress_history: bool
+
+
+POST_BUILD_SUPPRESS_HISTORY_FIXTURES: list[PostBuildSuppressHistoryFixture] = [
+    PostBuildSuppressHistoryFixture(
+        test_id="default",
+        suppress_history=None,
+        expected_suppress_history=True,
+    ),
+    PostBuildSuppressHistoryFixture(
+        test_id="explicit-false",
+        suppress_history=False,
+        expected_suppress_history=False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(PostBuildSuppressHistoryFixture._fields),
+    POST_BUILD_SUPPRESS_HISTORY_FIXTURES,
+    ids=[fixture.test_id for fixture in POST_BUILD_SUPPRESS_HISTORY_FIXTURES],
+)
+def test_post_build_commands_honor_suppress_history(
+    session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    test_id: str,
+    suppress_history: bool | None,
+    expected_suppress_history: bool,
+) -> None:
+    """Post-build commands use the window suppress_history setting."""
+    sent: list[tuple[str | None, bool | None]] = []
+    original_send_keys = Pane.send_keys
+
+    def spy_send_keys(
+        self: Pane,
+        cmd: str | None = None,
+        enter: bool | None = True,
+        suppress_history: bool | None = False,
+        literal: bool | None = False,
+        reset: bool | None = None,
+        copy_mode_cmd: str | None = None,
+        repeat: int | None = None,
+        expand_formats: bool | None = None,
+        hex_keys: bool | None = None,
+        target_client: str | None = None,
+        key_name: bool | None = None,
+    ) -> None:
+        sent.append((cmd, suppress_history))
+        original_send_keys(
+            self,
+            cmd=cmd,
+            enter=enter,
+            suppress_history=suppress_history,
+            literal=literal,
+            reset=reset,
+            copy_mode_cmd=copy_mode_cmd,
+            repeat=repeat,
+            expand_formats=expand_formats,
+            hex_keys=hex_keys,
+            target_client=target_client,
+            key_name=key_name,
+        )
+
+    monkeypatch.setattr(Pane, "send_keys", spy_send_keys)
+
+    window_config: dict[str, t.Any] = {
+        "window_name": f"post-build-history-{test_id}",
+        "shell_command_after": ["echo __POST_BUILD_AFTER__"],
+        "clear": True,
+        "panes": ["echo pane"],
+    }
+    if suppress_history is not None:
+        window_config["suppress_history"] = suppress_history
+
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        "windows": [window_config],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    builder.build(session=session)
+
+    assert ("echo __POST_BUILD_AFTER__", expected_suppress_history) in sent
+    assert ("clear", expected_suppress_history) in sent
+
+
 def test_window_shell(
     session: Session,
 ) -> None:

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -422,23 +422,52 @@ def test_synchronize_builder_options(
     assert session.windows[0].show_option("synchronize-panes") is expected_synchronized
 
 
-def test_synchronize_after_runs_shell_command_after_once_per_pane(
+class SyncFanoutFixture(t.NamedTuple):
+    """Fixture for shell_command_after under synchronize-panes modes."""
+
+    test_id: str
+    window_extra: dict[str, t.Any]
+
+
+SYNC_FANOUT_FIXTURES: list[SyncFanoutFixture] = [
+    SyncFanoutFixture(test_id="sync_after", window_extra={"synchronize": "after"}),
+    SyncFanoutFixture(test_id="sync_before", window_extra={"synchronize": "before"}),
+    SyncFanoutFixture(test_id="sync_true", window_extra={"synchronize": True}),
+    SyncFanoutFixture(
+        test_id="explicit_option",
+        window_extra={"options": {"synchronize-panes": "on"}},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(SyncFanoutFixture._fields),
+    SYNC_FANOUT_FIXTURES,
+    ids=[fixture.test_id for fixture in SYNC_FANOUT_FIXTURES],
+)
+def test_shell_command_after_runs_once_per_pane_when_synchronized(
     session: Session,
+    test_id: str,
+    window_extra: dict[str, t.Any],
 ) -> None:
-    """synchronize: after does not mirror shell_command_after across panes."""
+    """shell_command_after runs exactly once per pane in every sync mode.
+
+    tmux mirrors send-keys across panes while synchronize-panes is on,
+    whether the option was enabled before the build (before/true or an
+    explicit option) or queued for after (options_after ordering).
+    """
+    window_config: dict[str, t.Any] = {
+        "window_name": f"sync-cmds-{test_id}",
+        "shell_command_after": [
+            "echo __SYNC_AF''TER__",
+            "echo __SYNC_DO''NE__",
+        ],
+        "panes": ["echo pane0", "echo pane1"],
+    }
+    window_config.update(window_extra)
     workspace: dict[str, t.Any] = {
         "session_name": session.name,
-        "windows": [
-            {
-                "window_name": "sync-after-cmds",
-                "synchronize": "after",
-                "shell_command_after": [
-                    "echo __SYNC_AF''TER__",
-                    "echo __SYNC_DO''NE__",
-                ],
-                "panes": ["echo pane0", "echo pane1"],
-            },
-        ],
+        "windows": [window_config],
     }
     workspace = loader.expand(workspace)
 

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -387,7 +387,7 @@ SYNCHRONIZE_BUILDER_FIXTURES: list[SynchronizeBuilderFixture] = [
     SynchronizeBuilderFixture(
         test_id="false",
         synchronize=False,
-        expected_synchronized=None,
+        expected_synchronized=False,
     ),
 ]
 
@@ -401,7 +401,7 @@ def test_synchronize_builder_options(
     session: Session,
     test_id: str,
     synchronize: bool | str,
-    expected_synchronized: bool,
+    expected_synchronized: bool | None,
 ) -> None:
     """Synchronize shorthand sets synchronize-panes on the built window."""
     workspace: dict[str, t.Any] = {
@@ -420,6 +420,180 @@ def test_synchronize_builder_options(
     builder.build(session=session)
 
     assert session.windows[0].show_option("synchronize-panes") is expected_synchronized
+
+
+class SyncIsolationFixture(t.NamedTuple):
+    """Fixture for build-time synchronize-panes isolation."""
+
+    test_id: str
+    window_extra: dict[str, t.Any]
+    global_synchronize: bool
+    expected_local_sync: bool | None
+    expected_effective_sync: bool
+
+
+SYNC_ISOLATION_FIXTURES: list[SyncIsolationFixture] = [
+    SyncIsolationFixture(
+        test_id="sync_before",
+        window_extra={"synchronize": "before"},
+        global_synchronize=False,
+        expected_local_sync=True,
+        expected_effective_sync=True,
+    ),
+    SyncIsolationFixture(
+        test_id="sync_true",
+        window_extra={"synchronize": True},
+        global_synchronize=False,
+        expected_local_sync=True,
+        expected_effective_sync=True,
+    ),
+    SyncIsolationFixture(
+        test_id="sync_after",
+        window_extra={"synchronize": "after"},
+        global_synchronize=False,
+        expected_local_sync=True,
+        expected_effective_sync=True,
+    ),
+    SyncIsolationFixture(
+        test_id="explicit_options_on",
+        window_extra={"options": {"synchronize-panes": "on"}},
+        global_synchronize=False,
+        expected_local_sync=True,
+        expected_effective_sync=True,
+    ),
+    SyncIsolationFixture(
+        test_id="explicit_options_after_on",
+        window_extra={"options_after": {"synchronize-panes": "on"}},
+        global_synchronize=False,
+        expected_local_sync=True,
+        expected_effective_sync=True,
+    ),
+    SyncIsolationFixture(
+        test_id="inherits_global_on",
+        window_extra={},
+        global_synchronize=True,
+        expected_local_sync=None,
+        expected_effective_sync=True,
+    ),
+    SyncIsolationFixture(
+        test_id="sync_false_overrides_global_on",
+        window_extra={"synchronize": False},
+        global_synchronize=True,
+        expected_local_sync=False,
+        expected_effective_sync=False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(SyncIsolationFixture._fields),
+    SYNC_ISOLATION_FIXTURES,
+    ids=[fixture.test_id for fixture in SYNC_ISOLATION_FIXTURES],
+)
+def test_synchronize_keeps_setup_commands_isolated(
+    session: Session,
+    test_id: str,
+    window_extra: dict[str, t.Any],
+    global_synchronize: bool,
+    expected_local_sync: bool | None,
+    expected_effective_sync: bool,
+) -> None:
+    """Pane setup commands are never broadcast while a window is building."""
+    if global_synchronize:
+        session.server.cmd("set-window-option", "-g", "synchronize-panes", "on")
+
+    window_config: dict[str, t.Any] = {
+        "window_name": f"sync-isolated-{test_id}",
+        "panes": [
+            "printf '__PANE0__\\n'",
+            "printf '__PANE1__\\n'",
+        ],
+    }
+    window_config.update(window_extra)
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        "windows": [window_config],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    builder.build(session=session)
+
+    window = session.windows[0]
+    panes = window.panes
+
+    def output_lines(pane: Pane, marker: str) -> int:
+        return sum(1 for line in pane.capture_pane() if line.strip() == marker)
+
+    def setup_complete() -> bool:
+        return (
+            output_lines(panes[0], "__PANE0__") >= 1
+            and output_lines(panes[1], "__PANE1__") >= 1
+        )
+
+    assert retry_until(setup_complete), "Expected setup markers in their own panes"
+    assert output_lines(panes[0], "__PANE1__") == 0
+    assert output_lines(panes[1], "__PANE0__") == 0
+    assert window.show_option("synchronize-panes") is expected_local_sync
+    assert (
+        window.show_option("synchronize-panes", include_inherited=True)
+        is expected_effective_sync
+    )
+
+
+def test_synchronize_preserves_plugin_final_state(session: Session) -> None:
+    """Plugin-set synchronize-panes is restored after isolated setup."""
+
+    class SyncOnWindowCreatePlugin:
+        """Plugin that chooses synchronized panes as the final window state."""
+
+        def before_workspace_builder(self, session: Session) -> None:
+            """No-op workspace hook."""
+
+        def on_window_create(self, window: Window) -> None:
+            """Set the final synchronized state before pane setup starts."""
+            window.set_option("synchronize-panes", True)
+
+        def after_window_finished(self, window: Window) -> None:
+            """No-op window hook."""
+
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        "windows": [
+            {
+                "window_name": "sync-plugin-final",
+                "panes": [
+                    "printf '__PANE0__\\n'",
+                    "printf '__PANE1__\\n'",
+                ],
+            },
+        ],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(
+        session_config=workspace,
+        server=session.server,
+        plugins=[SyncOnWindowCreatePlugin()],
+    )
+    builder.build(session=session)
+
+    window = session.windows[0]
+    panes = window.panes
+
+    def output_lines(pane: Pane, marker: str) -> int:
+        return sum(1 for line in pane.capture_pane() if line.strip() == marker)
+
+    def setup_complete() -> bool:
+        return (
+            output_lines(panes[0], "__PANE0__") >= 1
+            and output_lines(panes[1], "__PANE1__") >= 1
+        )
+
+    assert retry_until(setup_complete), "Expected setup markers in their own panes"
+    assert output_lines(panes[0], "__PANE1__") == 0
+    assert output_lines(panes[1], "__PANE0__") == 0
+    assert window.show_option("synchronize-panes") is True
 
 
 class SyncFanoutFixture(t.NamedTuple):
@@ -452,9 +626,8 @@ def test_shell_command_after_runs_once_per_pane_when_synchronized(
 ) -> None:
     """shell_command_after runs exactly once per pane in every sync mode.
 
-    tmux mirrors send-keys across panes while synchronize-panes is on,
-    whether the option was enabled before the build (before/true or an
-    explicit option) or queued for after (options_after ordering).
+    tmuxp keeps synchronize-panes off while it sends post-build commands,
+    then restores the final configured synchronize-panes state afterward.
     """
     window_config: dict[str, t.Any] = {
         "window_name": f"sync-cmds-{test_id}",

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -593,44 +593,51 @@ def test_synchronize_keeps_setup_commands_isolated(
     )
 
 
-def test_synchronize_preserves_plugin_final_state(session: Session) -> None:
-    """Plugin-set synchronize-panes is restored after isolated setup."""
+class SyncPluginOverrideFixture(t.NamedTuple):
+    """Fixture for plugin synchronize-panes override behavior."""
 
-    class SyncOnWindowCreatePlugin:
-        """Plugin that chooses synchronized panes as the final window state."""
+    test_id: str
+    window_extra: dict[str, t.Any]
+    plugin_synchronize: bool
+    expected_synchronized: bool
 
-        def before_workspace_builder(self, session: Session) -> None:
-            """No-op workspace hook."""
 
-        def on_window_create(self, window: Window) -> None:
-            """Set the final synchronized state before pane setup starts."""
-            window.set_option("synchronize-panes", True)
+SYNC_PLUGIN_OVERRIDE_FIXTURES: list[SyncPluginOverrideFixture] = [
+    SyncPluginOverrideFixture(
+        test_id="no_config_plugin_on",
+        window_extra={},
+        plugin_synchronize=True,
+        expected_synchronized=True,
+    ),
+    SyncPluginOverrideFixture(
+        test_id="options_on_plugin_off",
+        window_extra={"options": {"synchronize-panes": "on"}},
+        plugin_synchronize=False,
+        expected_synchronized=False,
+    ),
+    SyncPluginOverrideFixture(
+        test_id="options_off_plugin_on",
+        window_extra={"options": {"synchronize-panes": "off"}},
+        plugin_synchronize=True,
+        expected_synchronized=True,
+    ),
+    SyncPluginOverrideFixture(
+        test_id="synchronize_true_plugin_off",
+        window_extra={"synchronize": True},
+        plugin_synchronize=False,
+        expected_synchronized=False,
+    ),
+    SyncPluginOverrideFixture(
+        test_id="synchronize_false_plugin_on",
+        window_extra={"synchronize": False},
+        plugin_synchronize=True,
+        expected_synchronized=True,
+    ),
+]
 
-        def after_window_finished(self, window: Window) -> None:
-            """No-op window hook."""
 
-    workspace: dict[str, t.Any] = {
-        "session_name": session.name,
-        "windows": [
-            {
-                "window_name": "sync-plugin-final",
-                "panes": [
-                    "printf '__PANE0__\\n'",
-                    "printf '__PANE1__\\n'",
-                ],
-            },
-        ],
-    }
-    workspace = loader.expand(workspace)
-
-    builder = WorkspaceBuilder(
-        session_config=workspace,
-        server=session.server,
-        plugins=[SyncOnWindowCreatePlugin()],
-    )
-    builder.build(session=session)
-
-    window = session.windows[0]
+def _assert_synchronize_setup_isolated(window: Window) -> None:
+    """Assert pane setup commands did not broadcast across synchronized panes."""
     panes = window.panes
 
     def output_lines(pane: Pane, marker: str) -> int:
@@ -645,7 +652,147 @@ def test_synchronize_preserves_plugin_final_state(session: Session) -> None:
     assert retry_until(setup_complete), "Expected setup markers in their own panes"
     assert output_lines(panes[0], "__PANE1__") == 0
     assert output_lines(panes[1], "__PANE0__") == 0
-    assert window.show_option("synchronize-panes") is True
+
+
+def _build_synchronize_plugin_workspace(
+    session: Session,
+    test_id: str,
+    window_extra: dict[str, t.Any],
+    plugins: list[t.Any],
+) -> Window:
+    """Build a two-pane workspace for synchronize-panes plugin tests."""
+    window_config: dict[str, t.Any] = {
+        "window_name": f"sync-plugin-{test_id}",
+        "panes": [
+            "printf '__PANE0__\\n'",
+            "printf '__PANE1__\\n'",
+        ],
+    }
+    window_config.update(window_extra)
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        "windows": [window_config],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(
+        session_config=workspace,
+        server=session.server,
+        plugins=plugins,
+    )
+    builder.build(session=session)
+
+    window = session.windows[0]
+    _assert_synchronize_setup_isolated(window)
+    return window
+
+
+@pytest.mark.parametrize(
+    list(SyncPluginOverrideFixture._fields),
+    SYNC_PLUGIN_OVERRIDE_FIXTURES,
+    ids=[fixture.test_id for fixture in SYNC_PLUGIN_OVERRIDE_FIXTURES],
+)
+def test_synchronize_preserves_on_window_create_plugin_override(
+    session: Session,
+    test_id: str,
+    window_extra: dict[str, t.Any],
+    plugin_synchronize: bool,
+    expected_synchronized: bool,
+) -> None:
+    """on_window_create can override configured initial synchronize-panes state."""
+
+    class SyncOnWindowCreatePlugin:
+        """Plugin that chooses the final sync state before pane setup."""
+
+        def before_workspace_builder(self, session: Session) -> None:
+            """No-op workspace hook."""
+
+        def on_window_create(self, window: Window) -> None:
+            """Set the final synchronized state before pane setup starts."""
+            window.set_option("synchronize-panes", plugin_synchronize)
+
+        def after_window_finished(self, window: Window) -> None:
+            """No-op window hook."""
+
+    window = _build_synchronize_plugin_workspace(
+        session=session,
+        test_id=test_id,
+        window_extra=window_extra,
+        plugins=[SyncOnWindowCreatePlugin()],
+    )
+
+    assert window.show_option("synchronize-panes") is expected_synchronized
+
+
+class SyncPluginPrecedenceFixture(t.NamedTuple):
+    """Fixture for synchronize-panes plugin/config precedence."""
+
+    test_id: str
+    window_extra: dict[str, t.Any]
+    on_window_create_synchronize: bool
+    after_window_finished_synchronize: bool | None
+    expected_synchronized: bool
+
+
+SYNC_PLUGIN_PRECEDENCE_FIXTURES: list[SyncPluginPrecedenceFixture] = [
+    SyncPluginPrecedenceFixture(
+        test_id="options_after_on_overrides_on_window_create_off",
+        window_extra={"options_after": {"synchronize-panes": "on"}},
+        on_window_create_synchronize=False,
+        after_window_finished_synchronize=None,
+        expected_synchronized=True,
+    ),
+    SyncPluginPrecedenceFixture(
+        test_id="after_window_finished_overrides_options_after",
+        window_extra={"options_after": {"synchronize-panes": "on"}},
+        on_window_create_synchronize=False,
+        after_window_finished_synchronize=False,
+        expected_synchronized=False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(SyncPluginPrecedenceFixture._fields),
+    SYNC_PLUGIN_PRECEDENCE_FIXTURES,
+    ids=[fixture.test_id for fixture in SYNC_PLUGIN_PRECEDENCE_FIXTURES],
+)
+def test_synchronize_options_after_and_plugin_precedence(
+    session: Session,
+    test_id: str,
+    window_extra: dict[str, t.Any],
+    on_window_create_synchronize: bool,
+    after_window_finished_synchronize: bool | None,
+    expected_synchronized: bool,
+) -> None:
+    """options_after and after_window_finished keep their usual late precedence."""
+
+    class SyncPrecedencePlugin:
+        """Plugin that mutates sync state at both window hook boundaries."""
+
+        def before_workspace_builder(self, session: Session) -> None:
+            """No-op workspace hook."""
+
+        def on_window_create(self, window: Window) -> None:
+            """Set the synchronized state before pane setup starts."""
+            window.set_option("synchronize-panes", on_window_create_synchronize)
+
+        def after_window_finished(self, window: Window) -> None:
+            """Optionally set the synchronized state after options_after."""
+            if after_window_finished_synchronize is not None:
+                window.set_option(
+                    "synchronize-panes",
+                    after_window_finished_synchronize,
+                )
+
+    window = _build_synchronize_plugin_workspace(
+        session=session,
+        test_id=test_id,
+        window_extra=window_extra,
+        plugins=[SyncPrecedencePlugin()],
+    )
+
+    assert window.show_option("synchronize-panes") is expected_synchronized
 
 
 class SyncFanoutFixture(t.NamedTuple):

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -466,6 +466,7 @@ def test_synchronize_after_runs_shell_command_after_once_per_pane(
 
 def test_pane_titles(
     session: Session,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Pane title config sets pane-border options and pane titles."""
     workspace: dict[str, t.Any] = {
@@ -477,7 +478,8 @@ def test_pane_titles(
                 "panes": [
                     {"title": "editor", "shell_command": ["echo pane0"]},
                     {"title": "runner", "shell_command": ["echo pane1"]},
-                    {"shell_command": ["echo pane2"]},
+                    {"title": "", "shell_command": ["echo pane2"]},
+                    {"shell_command": ["echo pane3"]},
                 ],
             },
         ],
@@ -485,14 +487,15 @@ def test_pane_titles(
     workspace = loader.expand(workspace)
 
     builder = WorkspaceBuilder(session_config=workspace, server=session.server)
-    builder.build(session=session)
+    with caplog.at_level(logging.WARNING, logger="tmuxp.workspace.builder"):
+        builder.build(session=session)
 
     window = session.windows[0]
     assert window.show_option("pane-border-status") == "top"
     assert window.show_option("pane-border-format") == "#{pane_index}: #{pane_title}"
 
     panes = window.panes
-    assert len(panes) == 3
+    assert len(panes) == 4
 
     def check_title(pane: Pane, expected: str) -> bool:
         pane.refresh()
@@ -504,6 +507,15 @@ def test_pane_titles(
     assert retry_until(functools.partial(check_title, panes[1], "runner")), (
         f"Expected title 'runner', got {panes[1].pane_title!r}"
     )
+
+    # tmux discards empty titles; an explicit title: "" warns instead
+    blank_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING and hasattr(record, "tmux_pane")
+    ]
+    assert len(blank_warnings) == 1
+    assert blank_warnings[0].tmux_pane == panes[2].pane_id
 
 
 class ClearBuilderFixture(t.NamedTuple):

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -422,6 +422,58 @@ def test_synchronize_builder_options(
     assert session.windows[0].show_option("synchronize-panes") is expected_synchronized
 
 
+class IteratorSynchronizeOptionFixture(t.NamedTuple):
+    """Fixture for direct iterator synchronize-panes option behavior."""
+
+    test_id: str
+    option_value: str
+    expected_synchronized: bool
+
+
+ITERATOR_SYNCHRONIZE_OPTION_FIXTURES: list[IteratorSynchronizeOptionFixture] = [
+    IteratorSynchronizeOptionFixture(
+        test_id="on",
+        option_value="on",
+        expected_synchronized=True,
+    ),
+    IteratorSynchronizeOptionFixture(
+        test_id="off",
+        option_value="off",
+        expected_synchronized=False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(IteratorSynchronizeOptionFixture._fields),
+    ITERATOR_SYNCHRONIZE_OPTION_FIXTURES,
+    ids=[fixture.test_id for fixture in ITERATOR_SYNCHRONIZE_OPTION_FIXTURES],
+)
+def test_iter_create_windows_preserves_raw_synchronize_panes_option(
+    session: Session,
+    test_id: str,
+    option_value: str,
+    expected_synchronized: bool,
+) -> None:
+    """Direct iter_create_windows() calls apply raw synchronize-panes options."""
+    workspace: dict[str, t.Any] = {
+        "session_name": session.name,
+        "windows": [
+            {
+                "window_name": f"iterator-sync-{test_id}",
+                "options": {"synchronize-panes": option_value},
+                "panes": ["echo pane0"],
+            },
+        ],
+    }
+    workspace = loader.expand(workspace)
+
+    builder = WorkspaceBuilder(session_config=workspace, server=session.server)
+    window, _window_config = next(builder.iter_create_windows(session=session))
+
+    assert window.show_option("synchronize-panes") is expected_synchronized
+
+
 class SyncIsolationFixture(t.NamedTuple):
     """Fixture for build-time synchronize-panes isolation."""
 

--- a/tests/workspace/test_config.py
+++ b/tests/workspace/test_config.py
@@ -333,6 +333,217 @@ def test_validate_plugins() -> None:
         assert excinfo.match("only supports list type")
 
 
+class SynchronizeFixture(t.NamedTuple):
+    """Fixture for synchronize shorthand expansion."""
+
+    test_id: str
+    synchronize: bool | str
+    expected_section: str | None
+
+
+SYNCHRONIZE_FIXTURES: list[SynchronizeFixture] = [
+    SynchronizeFixture(
+        test_id="true-enables-before",
+        synchronize=True,
+        expected_section="options",
+    ),
+    SynchronizeFixture(
+        test_id="before-enables-before",
+        synchronize="before",
+        expected_section="options",
+    ),
+    SynchronizeFixture(
+        test_id="after-enables-after",
+        synchronize="after",
+        expected_section="options_after",
+    ),
+    SynchronizeFixture(
+        test_id="false-only-removes-key",
+        synchronize=False,
+        expected_section=None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(SynchronizeFixture._fields),
+    SYNCHRONIZE_FIXTURES,
+    ids=[fixture.test_id for fixture in SYNCHRONIZE_FIXTURES],
+)
+def test_expand_synchronize(
+    test_id: str,
+    synchronize: bool | str,
+    expected_section: str | None,
+) -> None:
+    """expand() desugars synchronize into tmux window options."""
+    workspace: dict[str, t.Any] = {
+        "session_name": f"sync-{test_id}",
+        "windows": [
+            {
+                "window_name": "main",
+                "synchronize": synchronize,
+                "panes": [{"shell_command": ["echo hi"]}],
+            },
+        ],
+    }
+
+    result = loader.expand(workspace)
+    window = result["windows"][0]
+
+    assert "synchronize" not in window
+    if expected_section is None:
+        assert "synchronize-panes" not in window.get("options", {})
+        assert "synchronize-panes" not in window.get("options_after", {})
+    else:
+        assert window[expected_section]["synchronize-panes"] == "on"
+
+
+class ShellCommandAfterFixture(t.NamedTuple):
+    """Fixture for shell_command_after expansion."""
+
+    test_id: str
+    shell_command_after: str | list[str]
+    expected_commands: list[str]
+
+
+SHELL_COMMAND_AFTER_FIXTURES: list[ShellCommandAfterFixture] = [
+    ShellCommandAfterFixture(
+        test_id="string-command",
+        shell_command_after="echo done",
+        expected_commands=["echo done"],
+    ),
+    ShellCommandAfterFixture(
+        test_id="list-commands",
+        shell_command_after=["echo done", "echo bye"],
+        expected_commands=["echo done", "echo bye"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(ShellCommandAfterFixture._fields),
+    SHELL_COMMAND_AFTER_FIXTURES,
+    ids=[fixture.test_id for fixture in SHELL_COMMAND_AFTER_FIXTURES],
+)
+def test_expand_shell_command_after(
+    test_id: str,
+    shell_command_after: str | list[str],
+    expected_commands: list[str],
+) -> None:
+    """expand() normalizes shell_command_after like shell_command_before."""
+    workspace: dict[str, t.Any] = {
+        "session_name": f"after-{test_id}",
+        "windows": [
+            {
+                "window_name": "main",
+                "shell_command_after": shell_command_after,
+                "panes": [{"shell_command": ["echo hi"]}],
+            },
+        ],
+    }
+
+    result = loader.expand(workspace)
+    after = result["windows"][0]["shell_command_after"]
+
+    assert [cmd["cmd"] for cmd in after["shell_command"]] == expected_commands
+
+
+class PaneTitleFixture(t.NamedTuple):
+    """Fixture for pane title option expansion."""
+
+    test_id: str
+    enabled: bool
+    position: str | None
+    expected_position: str | None
+    expect_warning: bool
+
+
+PANE_TITLE_FIXTURES: list[PaneTitleFixture] = [
+    PaneTitleFixture(
+        test_id="enabled-defaults",
+        enabled=True,
+        position=None,
+        expected_position="top",
+        expect_warning=False,
+    ),
+    PaneTitleFixture(
+        test_id="enabled-bottom",
+        enabled=True,
+        position="bottom",
+        expected_position="bottom",
+        expect_warning=False,
+    ),
+    PaneTitleFixture(
+        test_id="enabled-invalid-falls-back",
+        enabled=True,
+        position="invalid",
+        expected_position="top",
+        expect_warning=True,
+    ),
+    PaneTitleFixture(
+        test_id="disabled-removes-session-keys",
+        enabled=False,
+        position="bottom",
+        expected_position=None,
+        expect_warning=False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(PaneTitleFixture._fields),
+    PANE_TITLE_FIXTURES,
+    ids=[fixture.test_id for fixture in PANE_TITLE_FIXTURES],
+)
+def test_expand_pane_titles(
+    caplog: pytest.LogCaptureFixture,
+    test_id: str,
+    enabled: bool,
+    position: str | None,
+    expected_position: str | None,
+    expect_warning: bool,
+) -> None:
+    """expand() turns session pane title keys into tmux window options."""
+    workspace: dict[str, t.Any] = {
+        "session_name": f"title-{test_id}",
+        "enable_pane_titles": enabled,
+        "pane_title_format": " #T ",
+        "windows": [
+            {
+                "window_name": "main",
+                "panes": [
+                    {"title": "editor", "shell_command": ["echo hi"]},
+                    {"shell_command": ["echo bye"]},
+                ],
+            },
+        ],
+    }
+    if position is not None:
+        workspace["pane_title_position"] = position
+
+    with caplog.at_level(logging.WARNING, logger="tmuxp.workspace.loader"):
+        result = loader.expand(workspace)
+
+    window = result["windows"][0]
+    assert "enable_pane_titles" not in result
+    assert "pane_title_position" not in result
+    assert "pane_title_format" not in result
+    assert window["panes"][0]["title"] == "editor"
+
+    if expected_position is None:
+        assert "pane-border-status" not in window.get("options", {})
+    else:
+        assert window["options"]["pane-border-status"] == expected_position
+        assert window["options"]["pane-border-format"] == " #T "
+
+    warnings = [
+        record for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    assert any("pane_title_position" in record.message for record in warnings) is (
+        expect_warning
+    )
+
+
 def test_expand_logs_debug(
     tmp_path: pathlib.Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/workspace/test_config.py
+++ b/tests/workspace/test_config.py
@@ -536,12 +536,14 @@ def test_expand_pane_titles(
         assert window["options"]["pane-border-status"] == expected_position
         assert window["options"]["pane-border-format"] == " #T "
 
-    warnings = [
-        record for record in caplog.records if record.levelno == logging.WARNING
+    position_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING and hasattr(record, "tmux_session")
     ]
-    assert any("pane_title_position" in record.message for record in warnings) is (
-        expect_warning
-    )
+    assert bool(position_warnings) is expect_warning
+    if expect_warning:
+        assert position_warnings[0].tmux_session == f"title-{test_id}"
 
 
 def test_expand_logs_debug(

--- a/tests/workspace/test_config.py
+++ b/tests/workspace/test_config.py
@@ -338,29 +338,40 @@ class SynchronizeFixture(t.NamedTuple):
 
     test_id: str
     synchronize: bool | str
-    expected_section: str | None
+    expected_final_sync: bool | None
+    expect_warning: bool
 
 
 SYNCHRONIZE_FIXTURES: list[SynchronizeFixture] = [
     SynchronizeFixture(
         test_id="true-enables-before",
         synchronize=True,
-        expected_section="options",
+        expected_final_sync=True,
+        expect_warning=False,
     ),
     SynchronizeFixture(
         test_id="before-enables-before",
         synchronize="before",
-        expected_section="options",
+        expected_final_sync=True,
+        expect_warning=False,
     ),
     SynchronizeFixture(
         test_id="after-enables-after",
         synchronize="after",
-        expected_section="options_after",
+        expected_final_sync=True,
+        expect_warning=False,
     ),
     SynchronizeFixture(
-        test_id="false-only-removes-key",
+        test_id="false-disables-final-sync",
         synchronize=False,
-        expected_section=None,
+        expected_final_sync=False,
+        expect_warning=False,
+    ),
+    SynchronizeFixture(
+        test_id="invalid-warns-and-removes-key",
+        synchronize="during",
+        expected_final_sync=None,
+        expect_warning=True,
     ),
 ]
 
@@ -371,11 +382,13 @@ SYNCHRONIZE_FIXTURES: list[SynchronizeFixture] = [
     ids=[fixture.test_id for fixture in SYNCHRONIZE_FIXTURES],
 )
 def test_expand_synchronize(
+    caplog: pytest.LogCaptureFixture,
     test_id: str,
     synchronize: bool | str,
-    expected_section: str | None,
+    expected_final_sync: bool | None,
+    expect_warning: bool,
 ) -> None:
-    """expand() desugars synchronize into tmux window options."""
+    """expand() normalizes synchronize without enabling tmux during build."""
     workspace: dict[str, t.Any] = {
         "session_name": f"sync-{test_id}",
         "windows": [
@@ -387,15 +400,28 @@ def test_expand_synchronize(
         ],
     }
 
-    result = loader.expand(workspace)
+    with caplog.at_level(logging.WARNING, logger="tmuxp.workspace.loader"):
+        result = loader.expand(workspace)
     window = result["windows"][0]
 
     assert "synchronize" not in window
-    if expected_section is None:
-        assert "synchronize-panes" not in window.get("options", {})
-        assert "synchronize-panes" not in window.get("options_after", {})
+    assert "synchronize-panes" not in window.get("options", {})
+    assert "synchronize-panes" not in window.get("options_after", {})
+    if expected_final_sync is None:
+        assert "_synchronize_panes" not in window
     else:
-        assert window[expected_section]["synchronize-panes"] == "on"
+        assert window["_synchronize_panes"] is expected_final_sync
+
+    synchronize_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING and hasattr(record, "tmux_window")
+    ]
+    assert bool(synchronize_warnings) is expect_warning
+    if expect_warning:
+        warning = t.cast(t.Any, synchronize_warnings[0])
+        assert warning.tmux_session == f"sync-{test_id}"
+        assert warning.tmux_window == "main"
 
 
 class ShellCommandAfterFixture(t.NamedTuple):


### PR DESCRIPTION
## Summary

Split from the parity recut work to keep the runtime config surface reviewable.

- add `synchronize`, `shell_command_after`, `clear`, and pane title config handling
- ensure `shell_command_after` and `clear` run before `options_after`, so `synchronize: after` does not duplicate commands
- document the runtime keys with focused examples and builder/config coverage

## Verification

Ran before commit:

```console
$ rm -rf docs/_build; uv run ruff check . --fix --show-fixes; uv run ruff format .; uv run mypy; uv run py.test --reruns 0 -vvv; just build-docs;
```

Result: ruff clean, format unchanged, mypy clean, pytest `815 passed, 2 skipped`, docs built successfully.

Stack: base PR for lifecycle hooks and importer fallback follow-ups.