### PR TITLE
py(deps[libtmux]) Bump 0.58.1 -> 0.59.0 (tmux 3.7 support)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.14']
-        tmux-version: ['3.2a', '3.3a', '3.4', '3.5', '3.6', 'master']
+        tmux-version: ['3.2a', '3.3a', '3.4', '3.5', '3.6', '3.7', 'master']
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,16 @@ $ tmuxp@next load yoursession
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+#### Minimum `libtmux~=0.59.0` (was `~=0.58.1`) (#1057)
+
+### What's new
+
+#### tmux 3.7 support (#1057)
+
+tmuxp now supports tmux 3.7, which joins 3.2a through 3.6 in the tested version range. There are no behavior changes for users on earlier tmux releases.
+
 ## tmuxp 1.70.1 (2026-06-16)
 
 tmuxp 1.70.1 bumps libtmux to 0.58.1, fixing a pytest 9.1 plugin import failure that broke test collection for projects using tmuxp's or libtmux's fixtures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ include = [
   { path = "conftest.py", format = "sdist" },
 ]
 dependencies = [
-  "libtmux~=0.58.1",
+  "libtmux~=0.59.0",
   "PyYAML>=6.0"
 ]
 

--- a/tests/workspace/test_builder.py
+++ b/tests/workspace/test_builder.py
@@ -1517,7 +1517,13 @@ def test_issue_800_default_size_many_windows(
         assert callable(builder.session.kill)
         builder.session.kill()
 
-        with pytest.raises(libtmux.exc.LibTmuxException, match="no space for new pane"):
+        # tmux 3.7 reworded this error from "no space for new pane" to
+        # "size or position no space for a new pane"; the optional "a "
+        # matches both wordings.
+        with pytest.raises(
+            libtmux.exc.LibTmuxException,
+            match=r"no space for (a )?new pane",
+        ):
             builder.build()
         return
 

--- a/uv.lock
+++ b/uv.lock
@@ -604,11 +604,11 @@ wheels = [
 
 [[package]]
 name = "libtmux"
-version = "0.58.1"
+version = "0.59.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/58/346776e0491ede33e1554a4bff9b545dbe9f3164e45abac483195938a1cf/libtmux-0.58.1.tar.gz", hash = "sha256:a294dd585aa419d4ecce36f3e55df656693743c97a0b5b5bb1e5fea31ada2482", size = 519541, upload-time = "2026-06-17T00:03:31.81Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/a3/4112c3e30f7620eaaef9e7445dc1c040a006ad83a071697136652014ea5a/libtmux-0.59.0.tar.gz", hash = "sha256:bc279de9626408a5460c752ef1cc1884fc93ad00f5cc43a6170f619bc1617cf1", size = 518313, upload-time = "2026-06-27T17:26:04.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/4d/e44ada32edfe947c40d4dfc596a6f5355400a16d08be06016bd754375e41/libtmux-0.58.1-py3-none-any.whl", hash = "sha256:ab0f47d03a59d674962bc23e36e188fcfa4a82b0f270d474afab519e3076839b", size = 113653, upload-time = "2026-06-17T00:03:30.48Z" },
+    { url = "https://files.pythonhosted.org/packages/52/37/76d812918faaff95ec28c8f4c5cfacacb125a3ece4f33bd09357da3093c8/libtmux-0.59.0-py3-none-any.whl", hash = "sha256:c2525cbd4243a7d8ff0228f48696097b2cb53b2ee34267d9f9a88330d6f05c21", size = 113864, upload-time = "2026-06-27T17:26:03.171Z" },
 ]
 
 [[package]]
@@ -1670,7 +1670,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "libtmux", specifier = "~=0.58.1" },
+    { name = "libtmux", specifier = "~=0.59.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Bump libtmux `~=0.58.1` → `~=0.59.0` (one upstream release)
- Add tmux **3.7** to the CI test grid
- Adapt the issue-800 regression test to tmux 3.7's reworded pane error
- No tmuxp code/API changes — `break_pane` is not called in tmuxp

libtmux 0.59.0 adds tmux 3.7 support and works around an upstream tmux 3.7 regression where `break-pane` crashed the server with a NULL-pointer dereference.

## Upstream changes

### libtmux 0.59.0 (2026-06-27)
- Add tmux 3.7 to the tested version matrix (3.2a–3.7)
- Fix: `Pane.break_pane` no longer crashes the tmux 3.7 server (#693)

Release: https://github.com/tmux-python/libtmux/releases/tag/v0.59.0

## Commits in this PR

1. `py(deps[libtmux]) Bump 0.58.1 -> 0.59.0` — pyproject.toml + uv.lock
2. `tests(builder): Match tmux 3.7 pane error wording` — widen the `pytest.raises` match to cover tmux 3.7's "size or position no space for a new pane" wording
3. `ci(tests[matrix]): Add tmux 3.7 to version grid` — `.github/workflows/tests.yml`
4. `docs(CHANGES): libtmux 0.59.0 floor bump, tmux 3.7` — changelog entry for 1.71.0

## Test plan

- [x] `uv run py.test` passes locally on tmux 3.7 (797 passed, 2 skipped)
- [x] `uv run mypy` passes (strict)
- [x] `uv run ruff check .` / `ruff format --check` pass
- [ ] CI green across tmux 3.2a–3.7 + master