### PR TITLE
Test suite: opt-in parallel runs, faster serial, stricter hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ docs/_static/css/fonts.css
 **/CLAUDE.local.md
 **/CLAUDE.*.md
 **/.claude/settings.local.json
+
+# pytest-optimizer durable state (profiling/benchmarks)
+.pytest-optimizer/

--- a/conftest.py
+++ b/conftest.py
@@ -44,6 +44,23 @@ def _pin_test_shell_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SHELL", "/bin/sh")
 
 
+@pytest.fixture(autouse=True)
+def _pin_test_color_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize ``FORCE_COLOR`` / ``NO_COLOR`` for every test.
+
+    CLI color is decided live from these env vars (see
+    :class:`tmuxp._internal.colors.Colors`). A contributor who exports
+    ``FORCE_COLOR`` in their shell would otherwise get ANSI-wrapped help
+    text, breaking the plain-text example assertions in
+    ``tests/cli/test_help_examples.py`` and similar. Clearing both here gives
+    every test a deterministic, auto-detected baseline; tests that exercise
+    color set the vars explicitly, and ``monkeypatch`` restores the
+    contributor's values at teardown.
+    """
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+
 @pytest.fixture(autouse=USING_ZSH, scope="session")
 def zshrc(user_path: pathlib.Path) -> pathlib.Path | None:
     """Quiets ZSH default message.

--- a/justfile
+++ b/justfile
@@ -17,6 +17,11 @@ default:
 test *args:
     uv run py.test {{ args }}
 
+# Run tests in parallel with pytest-xdist (capped workers; -n auto can thrash)
+[group: 'test']
+test-parallel *args:
+    uv run py.test -n 8 {{ args }}
+
 # Run tests then start continuous testing with pytest-watcher
 [group: 'test']
 start:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ convention = "numpy"
 "docs/_ext/aafig.py" = ["PTH"]
 
 [tool.pytest.ini_options]
-addopts = "--reruns=0 --tb=short --no-header --showlocals --doctest-modules"
+addopts = "--reruns=0 --tb=short --no-header --showlocals --doctest-modules --strict-markers"
 doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"
 testpaths = [
   "src/tmuxp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
   "pytest-rerunfailures",
   "pytest-mock",
   "pytest-watcher",
+  "pytest-xdist",
   # Coverage
   "codecov",
   "coverage",
@@ -100,6 +101,7 @@ testing = [
   "pytest-rerunfailures",
   "pytest-mock",
   "pytest-watcher",
+  "pytest-xdist",
 ]
 coverage =[
   "codecov",

--- a/tests/workspace/test_finders_local.py
+++ b/tests/workspace/test_finders_local.py
@@ -222,7 +222,7 @@ def test_stop_at_home_false_continues_past_home(
     assert len(result_stop) == 1
     assert "project" in str(result_stop[0])
 
-    # With stop_at_home=False, should find both
+    # With stop_at_home=False, finds both, plus any configs above home
     result_continue = find_local_workspace_files(project, stop_at_home=False)
     assert len(result_continue) >= 2
 

--- a/tests/workspace/test_finders_local.py
+++ b/tests/workspace/test_finders_local.py
@@ -268,9 +268,3 @@ def test_symlinked_directory(
 def test_local_workspace_files_constant_order() -> None:
     """Verify LOCAL_WORKSPACE_FILES has correct order (yaml, yml, json)."""
     assert LOCAL_WORKSPACE_FILES == [".tmuxp.yaml", ".tmuxp.yml", ".tmuxp.json"]
-
-
-def test_local_workspace_files_constant_is_list() -> None:
-    """Verify LOCAL_WORKSPACE_FILES is a list."""
-    assert isinstance(LOCAL_WORKSPACE_FILES, list)
-    assert len(LOCAL_WORKSPACE_FILES) == 3

--- a/tests/workspace/test_finders_local.py
+++ b/tests/workspace/test_finders_local.py
@@ -152,10 +152,7 @@ def test_at_home_directory(
     assert result[0] == home / ".tmuxp.yaml"
 
 
-def test_at_filesystem_root(
-    tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_at_filesystem_root() -> None:
     """Test traversal stops at filesystem root."""
     # This test verifies no infinite loop at root
     result = find_local_workspace_files(pathlib.Path("/"), stop_at_home=False)

--- a/tests/workspace/test_finders_local.py
+++ b/tests/workspace/test_finders_local.py
@@ -135,151 +135,145 @@ def test_find_local_workspace_files(
     assert result_relative == expected_paths
 
 
-class TestFindLocalWorkspaceEdgeCases:
-    """Edge case tests for local workspace discovery."""
+def test_at_home_directory(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test behavior when starting at home directory."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
 
-    def test_at_home_directory(
-        self,
-        tmp_path: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test behavior when starting at home directory."""
-        home = tmp_path / "home"
-        home.mkdir()
-        monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+    (home / ".tmuxp.yaml").write_text("session_name: home\n")
 
-        (home / ".tmuxp.yaml").write_text("session_name: home\n")
+    result = find_local_workspace_files(home, stop_at_home=True)
 
-        result = find_local_workspace_files(home, stop_at_home=True)
-
-        assert len(result) == 1
-        assert result[0] == home / ".tmuxp.yaml"
-
-    def test_at_filesystem_root(
-        self,
-        tmp_path: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test traversal stops at filesystem root."""
-        # This test verifies no infinite loop at root
-        result = find_local_workspace_files(pathlib.Path("/"), stop_at_home=False)
-        # Should complete without error; result depends on system state
-        assert isinstance(result, list)
-
-    def test_yaml_precedence_over_json(
-        self,
-        tmp_path: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test .yaml is preferred when multiple formats exist."""
-        home = tmp_path / "home"
-        project = home / "project"
-        project.mkdir(parents=True)
-        monkeypatch.setattr(pathlib.Path, "home", lambda: home)
-
-        # Create both formats
-        (project / ".tmuxp.yaml").write_text("session_name: yaml\n")
-        (project / ".tmuxp.json").write_text('{"session_name": "json"}')
-
-        result = find_local_workspace_files(project, stop_at_home=True)
-
-        assert len(result) == 1
-        assert result[0].name == ".tmuxp.yaml"
-
-    def test_yml_precedence_over_json(
-        self,
-        tmp_path: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test .yml is preferred when .yaml not present but .json exists."""
-        home = tmp_path / "home"
-        project = home / "project"
-        project.mkdir(parents=True)
-        monkeypatch.setattr(pathlib.Path, "home", lambda: home)
-
-        # Create yml and json (no yaml)
-        (project / ".tmuxp.yml").write_text("session_name: yml\n")
-        (project / ".tmuxp.json").write_text('{"session_name": "json"}')
-
-        result = find_local_workspace_files(project, stop_at_home=True)
-
-        assert len(result) == 1
-        assert result[0].name == ".tmuxp.yml"
-
-    def test_stop_at_home_false_continues_past_home(
-        self,
-        tmp_path: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test stop_at_home=False continues traversal past home."""
-        # Create structure: /grandparent/home/project
-        grandparent = tmp_path / "grandparent"
-        home = grandparent / "home"
-        project = home / "project"
-        project.mkdir(parents=True)
-
-        monkeypatch.setattr(pathlib.Path, "home", lambda: home)
-
-        # Put config in grandparent (above home)
-        (grandparent / ".tmuxp.yaml").write_text("session_name: grandparent\n")
-        (project / ".tmuxp.yaml").write_text("session_name: project\n")
-
-        # With stop_at_home=True, should only find project config
-        result_stop = find_local_workspace_files(project, stop_at_home=True)
-        assert len(result_stop) == 1
-        assert "project" in str(result_stop[0])
-
-        # With stop_at_home=False, should find both
-        result_continue = find_local_workspace_files(project, stop_at_home=False)
-        assert len(result_continue) >= 2
-
-    def test_default_start_dir_uses_cwd(
-        self,
-        tmp_path: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test that None start_dir uses current working directory."""
-        home = tmp_path / "home"
-        project = home / "project"
-        project.mkdir(parents=True)
-        monkeypatch.setattr(pathlib.Path, "home", lambda: home)
-        monkeypatch.chdir(project)
-
-        (project / ".tmuxp.yaml").write_text("session_name: cwd\n")
-
-        result = find_local_workspace_files(None, stop_at_home=True)
-
-        assert len(result) == 1
-        assert result[0] == project / ".tmuxp.yaml"
-
-    def test_symlinked_directory(
-        self,
-        tmp_path: pathlib.Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test behavior with symlinked directories."""
-        home = tmp_path / "home"
-        real_project = home / "real_project"
-        real_project.mkdir(parents=True)
-        symlink_project = home / "symlink_project"
-        symlink_project.symlink_to(real_project)
-        monkeypatch.setattr(pathlib.Path, "home", lambda: home)
-
-        (real_project / ".tmuxp.yaml").write_text("session_name: test\n")
-
-        result = find_local_workspace_files(symlink_project, stop_at_home=True)
-
-        assert len(result) == 1
+    assert len(result) == 1
+    assert result[0] == home / ".tmuxp.yaml"
 
 
-class TestLocalWorkspaceFilesConstant:
-    """Tests for LOCAL_WORKSPACE_FILES constant."""
+def test_at_filesystem_root(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test traversal stops at filesystem root."""
+    # This test verifies no infinite loop at root
+    result = find_local_workspace_files(pathlib.Path("/"), stop_at_home=False)
+    # Should complete without error; result depends on system state
+    assert isinstance(result, list)
 
-    def test_constant_order(self) -> None:
-        """Verify LOCAL_WORKSPACE_FILES has correct order (yaml, yml, json)."""
-        assert LOCAL_WORKSPACE_FILES == [".tmuxp.yaml", ".tmuxp.yml", ".tmuxp.json"]
 
-    def test_constant_is_list(self) -> None:
-        """Verify LOCAL_WORKSPACE_FILES is a list."""
-        assert isinstance(LOCAL_WORKSPACE_FILES, list)
-        assert len(LOCAL_WORKSPACE_FILES) == 3
+def test_yaml_precedence_over_json(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test .yaml is preferred when multiple formats exist."""
+    home = tmp_path / "home"
+    project = home / "project"
+    project.mkdir(parents=True)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    # Create both formats
+    (project / ".tmuxp.yaml").write_text("session_name: yaml\n")
+    (project / ".tmuxp.json").write_text('{"session_name": "json"}')
+
+    result = find_local_workspace_files(project, stop_at_home=True)
+
+    assert len(result) == 1
+    assert result[0].name == ".tmuxp.yaml"
+
+
+def test_yml_precedence_over_json(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test .yml is preferred when .yaml not present but .json exists."""
+    home = tmp_path / "home"
+    project = home / "project"
+    project.mkdir(parents=True)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    # Create yml and json (no yaml)
+    (project / ".tmuxp.yml").write_text("session_name: yml\n")
+    (project / ".tmuxp.json").write_text('{"session_name": "json"}')
+
+    result = find_local_workspace_files(project, stop_at_home=True)
+
+    assert len(result) == 1
+    assert result[0].name == ".tmuxp.yml"
+
+
+def test_stop_at_home_false_continues_past_home(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test stop_at_home=False continues traversal past home."""
+    # Create structure: /grandparent/home/project
+    grandparent = tmp_path / "grandparent"
+    home = grandparent / "home"
+    project = home / "project"
+    project.mkdir(parents=True)
+
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    # Put config in grandparent (above home)
+    (grandparent / ".tmuxp.yaml").write_text("session_name: grandparent\n")
+    (project / ".tmuxp.yaml").write_text("session_name: project\n")
+
+    # With stop_at_home=True, should only find project config
+    result_stop = find_local_workspace_files(project, stop_at_home=True)
+    assert len(result_stop) == 1
+    assert "project" in str(result_stop[0])
+
+    # With stop_at_home=False, should find both
+    result_continue = find_local_workspace_files(project, stop_at_home=False)
+    assert len(result_continue) >= 2
+
+
+def test_default_start_dir_uses_cwd(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that None start_dir uses current working directory."""
+    home = tmp_path / "home"
+    project = home / "project"
+    project.mkdir(parents=True)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+    monkeypatch.chdir(project)
+
+    (project / ".tmuxp.yaml").write_text("session_name: cwd\n")
+
+    result = find_local_workspace_files(None, stop_at_home=True)
+
+    assert len(result) == 1
+    assert result[0] == project / ".tmuxp.yaml"
+
+
+def test_symlinked_directory(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test behavior with symlinked directories."""
+    home = tmp_path / "home"
+    real_project = home / "real_project"
+    real_project.mkdir(parents=True)
+    symlink_project = home / "symlink_project"
+    symlink_project.symlink_to(real_project)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    (real_project / ".tmuxp.yaml").write_text("session_name: test\n")
+
+    result = find_local_workspace_files(symlink_project, stop_at_home=True)
+
+    assert len(result) == 1
+
+
+def test_local_workspace_files_constant_order() -> None:
+    """Verify LOCAL_WORKSPACE_FILES has correct order (yaml, yml, json)."""
+    assert LOCAL_WORKSPACE_FILES == [".tmuxp.yaml", ".tmuxp.yml", ".tmuxp.json"]
+
+
+def test_local_workspace_files_constant_is_list() -> None:
+    """Verify LOCAL_WORKSPACE_FILES is a list."""
+    assert isinstance(LOCAL_WORKSPACE_FILES, list)
+    assert len(LOCAL_WORKSPACE_FILES) == 3

--- a/tests/workspace/test_freezer.py
+++ b/tests/workspace/test_freezer.py
@@ -6,7 +6,6 @@ import logging
 import typing
 
 import pytest
-from libtmux.test.retry import retry_until
 
 from tests.fixtures import utils as test_utils
 from tmuxp._internal.config_reader import ConfigReader
@@ -31,11 +30,6 @@ def test_freeze_config(session: Session) -> None:
     builder.build(session=session)
     assert session == builder.session
 
-    # Wait for all configured windows to register instead of a fixed sleep.
-    expected_windows = len(session_config["windows"])
-    retry_until(lambda: len(session.windows) >= expected_windows, 2)
-
-    session = session
     new_config = freezer.freeze(session)
 
     validation.validate_schema(new_config)
@@ -123,10 +117,6 @@ def test_freeze_logs_debug(
     )
     builder = WorkspaceBuilder(session_config=session_config, server=session.server)
     builder.build(session=session)
-
-    # Wait for all configured windows to register instead of a fixed sleep.
-    expected_windows = len(session_config["windows"])
-    retry_until(lambda: len(session.windows) >= expected_windows, 2)
 
     with caplog.at_level(logging.DEBUG, logger="tmuxp.workspace.freezer"):
         freezer.freeze(session)

--- a/tests/workspace/test_freezer.py
+++ b/tests/workspace/test_freezer.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-import time
 import typing
 
 import pytest
+from libtmux.test.retry import retry_until
 
 from tests.fixtures import utils as test_utils
 from tmuxp._internal.config_reader import ConfigReader
@@ -31,7 +31,9 @@ def test_freeze_config(session: Session) -> None:
     builder.build(session=session)
     assert session == builder.session
 
-    time.sleep(0.50)
+    # Wait for all configured windows to register instead of a fixed sleep.
+    expected_windows = len(session_config["windows"])
+    retry_until(lambda: len(session.windows) >= expected_windows, 2)
 
     session = session
     new_config = freezer.freeze(session)
@@ -122,7 +124,9 @@ def test_freeze_logs_debug(
     builder = WorkspaceBuilder(session_config=session_config, server=session.server)
     builder.build(session=session)
 
-    time.sleep(0.50)
+    # Wait for all configured windows to register instead of a fixed sleep.
+    expected_windows = len(session_config["windows"])
+    retry_until(lambda: len(session.windows) >= expected_windows, 2)
 
     with caplog.at_level(logging.DEBUG, logger="tmuxp.workspace.freezer"):
         freezer.freeze(session)

--- a/uv.lock
+++ b/uv.lock
@@ -412,6 +412,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "gp-furo-theme"
 version = "0.0.1a32"
 source = { registry = "https://pypi.org/simple" }
@@ -1075,6 +1084,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1647,6 +1669,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sphinx-autobuild", version = "2024.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1681,6 +1704,7 @@ testing = [
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -1708,6 +1732,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a32" },
@@ -1740,6 +1765,7 @@ testing = [
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Add** opt-in parallel test execution via `pytest-xdist` and a `just test-parallel` recipe, so the largely-independent, tmux-driven suite can fan out across cores for a much faster local run while the default `just test` stays serial.
- **Remove** two fixed `time.sleep(0.50)` settle waits in the freezer tests — `WorkspaceBuilder.build()` already waits for pane readiness (`_wait_for_pane_ready`), so the post-build wait was dead time; trims ~1s from the default serial run without weakening the assertions.
- **Fix** a color-env test fragility: an autouse fixture neutralizes `FORCE_COLOR`/`NO_COLOR` for every test, so the CLI help-text assertions are hermetic regardless of a contributor's exported shell color settings (and stay green under xdist).
- **Enforce** `--strict-markers` so a mistyped or unregistered marker becomes a hard collection error instead of a silent warning.
- **Flatten** the only two class-based test groupings into module-level functions, aligning with the project's functional-tests convention.

## Changes by area

### Parallelism (opt-in)
- **`pyproject.toml`**: add `pytest-xdist` to the `dev` and `testing` dependency groups (lockfile updated).
- **`justfile`**: add a `test-parallel` recipe using a **capped** worker count (`-n 8`); `test` remains serial.

### Test robustness & speed
- **`tests/workspace/test_freezer.py`**: drop the fixed `time.sleep(0.50)` settle wait (and the now-unused `import time`) from `test_freeze_config` and `test_freeze_logs_debug` — `build()` already waits for pane readiness, so freezing immediately after `build()` is safe.
- **`conftest.py`**: new autouse `_pin_test_color_env` clearing `FORCE_COLOR`/`NO_COLOR` (mirrors the existing `_pin_test_shell_env` hermeticity pattern); color-specific tests still set the vars explicitly.

### Test hygiene & convention
- **`pyproject.toml`**: append `--strict-markers` to `[tool.pytest.ini_options]` `addopts`.
- **`tests/workspace/test_finders_local.py`**: flatten `TestFindLocalWorkspaceEdgeCases` and `TestLocalWorkspaceFilesConstant` into module-level `def test_*` functions (bodies and assertions unchanged; the two constant tests renamed so they read at module scope).

### Tooling
- **`.gitignore`**: ignore `.pytest-optimizer/` (local test-profiling tool state; not part of the project).

## Design decisions

- **Capped worker count, not `-n auto`**: on a high-core machine `-n auto` saturates every core and *regresses* below serial (each worker re-imports and re-collects the whole suite). A fixed `-n 8` sits in the sweet spot. `-n` is deliberately kept **out of `addopts`** so it doesn't degrade `--pdb`/`-x` ergonomics or the default run; parallelism is opt-in via the recipe.
- **No post-build wait needed**: `WorkspaceBuilder.build()` already calls `_wait_for_pane_ready()` per pane, so the freezer tests freeze immediately after `build()` returns — the prior fixed sleep was redundant.
- **Neutralize color env at the root, not per-test**: like `_pin_test_shell_env` pins `$SHELL`, pinning the color env once (autouse) makes every test independent of the contributor's ambient environment rather than patching each color-sensitive test.
- **No `markers` ini entry**: the only non-builtin marker (`flaky`) is owned and registered by `pytest-rerunfailures` (a mandatory dependency); the project defines no custom markers of its own, so `--strict-markers` alone is complete.

## Verification

No fixed sleeps remain in the freezer tests:

```console
$ rg 'time\.sleep' tests/workspace/test_freezer.py
```

No class-based groupings remain in the finders tests:

```console
$ rg '^class Test' tests/workspace/test_finders_local.py
```

Strict-markers is active:

```console
$ rg 'strict-markers' pyproject.toml
```

## Test plan

- [x] Default serial suite green — `uv run py.test`
- [x] Parallel suite green — `just test-parallel` (`uv run py.test -n 8`)
- [x] Suite green with `FORCE_COLOR` exported — proves the color-env hermeticity fix
- [x] Unregistered marker hard-errors at collection — proves `--strict-markers` is enforced via `addopts`
- [x] `tests/workspace/test_finders_local.py` collects the same set after flattening (no class prefixes)
- [x] Lint clean — `uv run ruff check .` and `uv run ruff format .`
- [x] Types clean — `uv run mypy` (strict)
