### PR TITLE
py(deps[libtmux]) Bump 0.59.0 -> 0.60.0 (tmux 3.7 feature parity)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,16 @@ $ tmuxp@next load yoursession
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+#### Minimum `libtmux~=0.60.0` (was `~=0.59.0`) (#1065)
+
+### What's new
+
+#### libtmux 0.60.0 completes tmux 3.7 feature parity (#1065)
+
+The libtmux floor bump brings tmux 3.7 feature parity to the library layer tmuxp builds on: floating panes ({meth}`~libtmux.Window.new_pane`), typed tmux 3.7 server, session, window, and pane options, new pane format variables, and new tmux 3.7 command flags. Every 3.7-only surface is version-gated, so tmux 3.2a-3.6 are unaffected. These APIs are reachable through tmuxp's Python API and `tmuxp shell`; the YAML workspace format is unchanged.
+
 ## tmuxp 1.71.0 (2026-06-27)
 
 tmuxp 1.71.0 bumps libtmux to 0.59.0, adding support for tmux 3.7.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ include = [
   { path = "conftest.py", format = "sdist" },
 ]
 dependencies = [
-  "libtmux~=0.59.0",
+  "libtmux~=0.60.0",
   "PyYAML>=6.0"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -604,11 +604,11 @@ wheels = [
 
 [[package]]
 name = "libtmux"
-version = "0.59.0"
+version = "0.60.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/a3/4112c3e30f7620eaaef9e7445dc1c040a006ad83a071697136652014ea5a/libtmux-0.59.0.tar.gz", hash = "sha256:bc279de9626408a5460c752ef1cc1884fc93ad00f5cc43a6170f619bc1617cf1", size = 518313, upload-time = "2026-06-27T17:26:04.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/c2fc23e871855cb3feb5119ab3426656b2caa83f220fb6f1b7a770cb887e/libtmux-0.60.0.tar.gz", hash = "sha256:03d9740fd18090378a1f1a763403b127808b327b1466a1d3812c562f595ce06f", size = 527549, upload-time = "2026-06-28T21:19:35.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/37/76d812918faaff95ec28c8f4c5cfacacb125a3ece4f33bd09357da3093c8/libtmux-0.59.0-py3-none-any.whl", hash = "sha256:c2525cbd4243a7d8ff0228f48696097b2cb53b2ee34267d9f9a88330d6f05c21", size = 113864, upload-time = "2026-06-27T17:26:03.171Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c3/e524f498fe5dfc26c975ec8b52332fdd0b50e020f3ecc09423ba5d4ebc61/libtmux-0.60.0-py3-none-any.whl", hash = "sha256:a085e5653709d9e1c809c68f7daf1cd55c8af1ca938eb1e866388b9b13905ed3", size = 117368, upload-time = "2026-06-28T21:19:33.635Z" },
 ]
 
 [[package]]
@@ -1670,7 +1670,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "libtmux", specifier = "~=0.59.0" },
+    { name = "libtmux", specifier = "~=0.60.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
## Summary

- **Bump** the `libtmux` floor `~=0.59.0` → `~=0.60.0` in `pyproject.toml`, with `uv.lock` updated to match.
- **Adopt** libtmux 0.60.0, which completes tmux 3.7 feature parity at the library layer — floating panes, typed 3.7 options, new pane format variables, and new command flags.
- **No migration needed**: every upstream addition is additive and version-gated, so tmuxp's behavior and its tmux 3.2a–3.6 support are unchanged. The YAML workspace format is untouched; the new libtmux APIs are reachable through tmuxp's Python API and `tmuxp shell`.

## Upstream — libtmux 0.60.0 (#694)

| Area | What 0.60.0 adds (all version-gated to tmux 3.7+) |
|---|---|
| Floating panes | `Window.new_pane()` / `Pane.new_pane()` |
| Options | Typed tmux 3.7 server / session / window / pane options |
| Pane formats | Floating geometry & flags, OSC 9;4 progress, screen-mode flags |
| Command flags | `capture_pane`, `split`, `Session.kill`, `paste_buffer`, `command_prompt`, `list_keys`, `run_shell`, `refresh_client` |

Release: https://github.com/tmux-python/libtmux/releases/tag/v0.60.0
Changelog: https://libtmux.git-pull.com/history.html#libtmux-0-60-0-2026-06-28

## Verification

The floor moved and no stale `0.59` pin remains in the manifest:

```console
$ rg 'libtmux~=' pyproject.toml
```

## Test plan

- [x] Full suite passes serially against libtmux 0.60.0 — `uv run py.test`
- [x] Docs build adds no new Sphinx warnings; the new `{meth}` `~libtmux.Window.new_pane` intersphinx ref resolves
- [ ] CI confirms `uv run mypy` (strict) and `uv run ruff check .` — no source files changed, so both are expected clean