### PR TITLE
Docs: build-time mermaid + tmux-layout diagram rendering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,38 @@ jobs:
         if: env.PUBLISH == 'true'
         uses: extractions/setup-just@v4
 
+      - name: Set up Node.js
+        if: env.PUBLISH == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Set up pnpm
+        if: env.PUBLISH == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Cache Puppeteer browser
+        if: env.PUBLISH == 'true'
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('docs/pnpm-lock.yaml') }}
+          restore-keys: |
+            puppeteer-${{ runner.os }}-
+
+      # Diagrams (docs/_ext/mermaid_inline.py) are rendered at build time by
+      # mmdc, which drives a headless Chrome. Without it the build still
+      # succeeds but degrades diagrams to a text fallback, so provision both.
+      - name: Install diagram toolchain (mermaid-cli + Chrome)
+        if: env.PUBLISH == 'true'
+        run: |
+          pnpm -C docs install --frozen-lockfile
+          pnpm -C docs rebuild puppeteer
+          pnpm -C docs exec mmdc --version
+
       - name: Print python versions
         if: env.PUBLISH == 'true'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Mermaid diagram tooling (docs/_ext/mermaid_inline.py)
+docs/node_modules/
+docs/_mermaid_cache/
+
 # PyBuilder
 target/
 

--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,16 @@ $ tmuxp@next load yoursession
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Documentation
+
+#### Themed diagrams across the docs (#1071)
+
+The docs now render their diagrams as theme-aware inline graphics that follow the
+site's light/dark palette and code styling, replacing the old static ASCII art.
+{ref}`workspace-builders` gains a load → build → attach flow diagram and opens
+with a concept-first overview, and {ref}`examples` shows each pane example as a
+faithful tmux window layout.
+
 ## tmuxp 1.73.0 (2026-06-28)
 
 tmuxp 1.73.0 makes the workspace build step pluggable and tunable. A workspace can now build through a third-party builder selected by registered entry-point name or Python import path, and a new `workspace_builder_options` catalog controls the pane-readiness wait per workspace. The built-in builder stays the default, so existing workspaces keep working — though the new `pane_readiness: auto` default skips the prompt wait on non-zsh shells. See {ref}`custom-workspace-builders` for the guide.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,80 @@
+# Documentation voice
+
+This file covers the *voice* of prose under `docs/` — how to frame a
+feature page so a reader meets the idea before its configuration. It
+complements the repository-root `AGENTS.md`, which already governs code
+blocks, shell-command formatting, changelog conventions, and MyST
+roles. When the two overlap, the root file wins; this one only answers
+the question it leaves open: how should the prose sound?
+
+## Who you are writing for
+
+The default reader runs tmuxp and writes workspace files in YAML or
+JSON. They are fluent in tmux itself — servers, sessions, windows,
+panes, layouts, the shell and its prompt — but you cannot assume they
+read Python, know tmuxp's internals, or have heard of its builder
+architecture, entry points, or `sys.path`.
+
+A second, smaller reader writes Python: custom builders, plugins, code
+against libtmux. Serve them too, but mark their material as opt-in
+("for the braver cases", "advanced") so the default reader knows they
+can stop. Never make the common case pay a comprehension tax for the
+advanced one.
+
+## Voice
+
+- **Second person, present tense, active.** "You name the builder", not
+  "The builder is selected". Address the reader who is doing the thing.
+- **Concept before configuration.** Open by saying what the thing *is*
+  and what it does for the reader. The YAML surface — the keys, the
+  flags — is the last detail they need, not the first. A page that
+  opens with "set these keys" has buried the idea under its mechanics.
+- **Say when they can stop.** Lead with the default and the
+  reassurance: most readers never touch this, it works out of the box,
+  everything here is optional. Let a skimmer leave after one sentence.
+- **Progressive disclosure.** Order by how many readers need it:
+  default → the one option a few will tune → swapping the whole thing
+  → writing your own. Each step is for a smaller audience than the last.
+- **Name the trade-off.** If an option costs something — load time, a
+  slower attach — say so, and say what it buys ("a little slower, but
+  the workspace is fully prepped before you attach"). State it; don't
+  sell it.
+- **Frame by concept, not by mechanism.** Don't call a feature "the
+  keys" or "the flags" in prose; that names the implementation surface,
+  which is the reader's last concern. Name the concept. The mechanics
+  vocabulary — a `Key` / `Type` / `Default` table — is correct in a
+  reference table, and only there.
+
+## What stays precise
+
+Warm the framing, never the facts. Resolution-order lists, value
+tables, exact error strings, and class or function cross-references
+carry meaning in their exact form — leave them alone. The friendly
+voice belongs in the sentences *around* a precise block, introducing
+it, not inside it paraphrasing it into vagueness.
+
+## Cross-references
+
+Point the advanced reader at the deep-dive rather than inlining it, and
+put the link where their interest peaks — on the phrase that made them
+curious ("write your own") — not as a standalone footnote the eye
+skips. Use the MyST roles listed in the root `AGENTS.md`.
+
+## A page that does this
+
+`docs/configuration/workspace-builders.md` is the worked example:
+a concept-first intro, an out-of-the-box reassurance, sections ordered
+by shrinking audience, an honest trade-off on the prompt wait, and
+precise reference tables left precise. Read it before reshaping another
+page.
+
+## Before you commit
+
+- Does the page open with what the feature *is*, or with how to
+  configure it?
+- Can a reader who needs only the default stop after the first
+  paragraph?
+- Is anything framed as "the keys/flags" that should be named by
+  concept instead?
+- Are the advanced and Python-only parts clearly marked opt-in?
+- Did you leave every table, error string, and cross-reference exact?

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/_ext/mermaid_inline.py
+++ b/docs/_ext/mermaid_inline.py
@@ -48,7 +48,7 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 #: Bump to invalidate the on-disk render cache when render arguments change.
-_RENDER_VERSION = "mmdc11-furo-svg-v1"
+_RENDER_VERSION = "mmdc11-furo-svg-v2"
 
 #: Logical names for the two inlined variants (cache key, SVG id, CSS class).
 _THEME_LIGHT = "light"
@@ -88,6 +88,20 @@ _PALETTES: dict[str, dict[str, str]] = {
         "fontFamily": _FONT_STACK,
     },
 }
+
+#: Extra CSS injected into every rendered SVG (theme-agnostic). Nodes tagged
+#: ``:::cmd`` render in a monospace font so commands read as code; edge labels
+#: get padding. ``white-space: normal`` lets a padded label keep wrapping
+#: instead of overflowing the box mermaid measured for it.
+_MONO_STACK = "'SFMono-Regular', Menlo, Consolas, Monaco, 'Liberation Mono', monospace"
+_THEME_CSS = (
+    ".cmd .nodeLabel { font-family: " + _MONO_STACK + " !important; }"
+    " .edgeLabels .labelBkg {"
+    " padding: 3px 10px !important;"
+    " white-space: normal !important;"
+    " border-radius: 4px;"
+    " }"
+)
 
 #: mermaid hardcodes this id on every rendered SVG and scopes its CSS and
 #: arrowhead markers to it; it is rewritten per diagram+theme to avoid
@@ -303,6 +317,7 @@ def _render(app: Sphinx, source: str, theme: str) -> str:
         config: dict[str, t.Any] = {
             "theme": "base",
             "themeVariables": _PALETTES[theme],
+            "themeCSS": _THEME_CSS,
         }
         config_file.write_text(json.dumps(config), encoding="utf-8")
         argv = [

--- a/docs/_ext/mermaid_inline.py
+++ b/docs/_ext/mermaid_inline.py
@@ -1,0 +1,364 @@
+"""Build-time mermaid rendering for Sphinx, producing inline SVG.
+
+Renders fenced ``mermaid`` blocks to inline ``<svg>`` at build time via
+``mmdc`` (`@mermaid-js/mermaid-cli`_), so diagrams paint with the page: there is
+no client-side mermaid runtime, no asynchronous pop-in, and no layout shift. The
+finished SVG ships inside ``.article-container``, so it also rides through
+gp-sphinx's SPA navigation as live DOM with zero re-initialisation.
+
+Each diagram is rendered twice — a light and a dark variant — and both are
+inlined, toggled by CSS on ``body[data-theme]`` (see ``gp-diagram.css``). Mermaid
+bakes literal colours into an id-scoped, ``!important`` ``<style>`` block, so a
+single SVG cannot be re-themed by external CSS; shipping both variants is the
+zero-JavaScript path that stays correct across theme switches and SPA swaps.
+
+Authoring (``myst_fence_as_directive=["mermaid"]`` routes the plain fence)::
+
+    ```mermaid
+    flowchart LR
+        a --> b
+    ```
+
+.. _`@mermaid-js/mermaid-cli`: https://github.com/mermaid-js/mermaid-cli
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import tempfile
+import typing as t
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.util import logging
+from sphinx.util.docutils import SphinxDirective
+
+if t.TYPE_CHECKING:
+    from sphinx.application import Sphinx
+    from sphinx.writers.html5 import HTML5Translator
+
+logger = logging.getLogger(__name__)
+
+#: Bump to invalidate the on-disk render cache when render arguments change.
+_RENDER_VERSION = "mmdc11-svg-v1"
+
+#: mermaid theme presets used for the two inlined variants.
+_THEME_LIGHT = "default"
+_THEME_DARK = "dark"
+
+#: mermaid hardcodes this id on every rendered SVG and scopes its CSS and
+#: arrowhead markers to it; it is rewritten per diagram+theme to avoid
+#: duplicate-id collisions when both variants are inlined on one page.
+_MERMAID_DEFAULT_ID = "my-svg"
+
+_VIEWBOX_RE = re.compile(r'viewBox="0 0 ([\d.]+) ([\d.]+)"')
+
+#: Guards the "renderer missing/failed" warning so it fires once, not per node.
+_render_warned = False
+
+
+class MermaidError(Exception):
+    """Base class for build-time mermaid rendering failures."""
+
+
+class MermaidRendererMissing(MermaidError):
+    """``mmdc`` could not be located in the docs toolchain."""
+
+
+class MermaidRenderError(MermaidError):
+    """``mmdc`` ran but failed to produce an SVG."""
+
+
+class mermaid_inline(nodes.General, nodes.Element):
+    """Doctree node carrying mermaid source until the HTML write phase."""
+
+
+def _diagram_digest(source: str, theme: str, *, version: str = _RENDER_VERSION) -> str:
+    """Return a stable content hash that keys the render cache.
+
+    The hash covers the render version, the theme, and the source, so light and
+    dark variants cache separately and a render-argument change busts the cache.
+
+    >>> a = _diagram_digest("flowchart LR a-->b", "default")
+    >>> a == _diagram_digest("flowchart LR a-->b", "default")
+    True
+    >>> a != _diagram_digest("flowchart LR a-->b", "dark")
+    True
+    >>> len(a)
+    40
+    """
+    payload = f"{version}\x00{theme}\x00{source}"
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def _svg_element_id(digest: str, theme: str) -> str:
+    """Return a per-diagram, per-theme SVG id replacing mermaid's ``my-svg``.
+
+    >>> _svg_element_id("abcdef1234567890", "light")
+    'mermaid-abcdef123456-light'
+    """
+    return f"mermaid-{digest[:12]}-{theme}"
+
+
+def _normalize_svg(svg: str, *, svg_id: str) -> str:
+    """Make an ``mmdc`` SVG safe to inline: unique id, explicit size, no max-width.
+
+    Three fixes are applied to mermaid's default output:
+
+    1. The hardcoded ``my-svg`` id token — used by the id attribute, the
+       id-scoped ``<style>`` rules, and ``url(#my-svg_...)`` marker references —
+       is rewritten to ``svg_id`` so two variants never collide on duplicate ids.
+    2. The root ``width="100%"`` (mermaid emits no ``height``) is replaced with
+       explicit ``width``/``height`` taken from the ``viewBox``, so the browser
+       reserves the diagram's box in the first layout pass — before any script.
+    3. The inline ``max-width: NNpx`` is stripped; paired with the stylesheet's
+       ``max-width: 100%; height: auto`` the diagram scales without reflow.
+
+    >>> svg = (
+    ...     '<svg id="my-svg" width="100%" '
+    ...     'style="max-width: 120px; background-color: transparent;" '
+    ...     'viewBox="0 0 120 40"><style>#my-svg{fill:#333;}</style>'
+    ...     '<g marker-end="url(#my-svg_end)"/></svg>'
+    ... )
+    >>> out = _normalize_svg(svg, svg_id="mermaid-abc-light")
+    >>> "my-svg" in out
+    False
+    >>> 'width="120"' in out and 'height="40"' in out
+    True
+    >>> "max-width" in out
+    False
+    >>> 'id="mermaid-abc-light"' in out and "url(#mermaid-abc-light_end)" in out
+    True
+    """
+    svg = svg.replace(_MERMAID_DEFAULT_ID, svg_id)
+    match = _VIEWBOX_RE.search(svg)
+    if match is not None:
+        width, height = match.group(1), match.group(2)
+        svg = re.sub(r'(<svg\b[^>]*?)\s+width="[^"]*"', r"\1", svg, count=1)
+        svg = re.sub(r"<svg\b", f'<svg width="{width}" height="{height}"', svg, count=1)
+    return re.sub(r"\s*max-width:\s*[\d.]+px;?", "", svg, count=1)
+
+
+class MermaidDirective(SphinxDirective):
+    """Stash a mermaid fence's source on a node for the write phase to render."""
+
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 0
+    option_spec: t.ClassVar[dict[str, t.Callable[[str], t.Any]]] = {
+        "caption": directives.unchanged,
+        "alt": directives.unchanged,
+        "name": directives.unchanged,
+    }
+
+    def run(self) -> list[nodes.Node]:
+        """Return a single :class:`mermaid_inline` node carrying the source."""
+        if not self.content:
+            warning = self.state.document.reporter.warning(
+                "mermaid directive has no content",
+                line=self.lineno,
+            )
+            return [warning]
+        node = mermaid_inline()
+        node["mermaid_source"] = "\n".join(self.content)
+        node["caption"] = self.options.get("caption", "")
+        node["alt"] = self.options.get("alt", "")
+        self.add_name(node)
+        self.set_source_info(node)
+        return [node]
+
+
+def _discover_chrome() -> str | None:
+    """Return a Chrome installed by ``puppeteer browsers install``, if any.
+
+    Puppeteer's automatic resolution can miss the cached browser (its cache dir
+    is computed relative to the install location); pointing ``executablePath`` at
+    the discovered binary sidesteps that. Linux/WSL layout only.
+    """
+    cache = pathlib.Path.home() / ".cache" / "puppeteer" / "chrome"
+    if not cache.is_dir():
+        return None
+    candidates = sorted(cache.glob("*/chrome-linux64/chrome"))
+    return str(candidates[-1]) if candidates else None
+
+
+def _resolve_mmdc(app: Sphinx) -> list[str] | None:
+    """Locate the ``mmdc`` executable: config, then docs-local, then ``PATH``."""
+    configured = app.config.mermaid_inline_cmd
+    if configured:
+        found = shutil.which(configured)
+        if found:
+            return [found]
+        path = pathlib.Path(configured)
+        if path.exists():
+            return [str(path)]
+    local = pathlib.Path(app.confdir) / "node_modules" / ".bin" / "mmdc"
+    if local.exists():
+        return [str(local)]
+    found = shutil.which("mmdc")
+    return [found] if found else None
+
+
+def _puppeteer_config_file(app: Sphinx, tmpdir: pathlib.Path) -> pathlib.Path:
+    """Write a puppeteer config (``--no-sandbox`` + resolved Chrome) and return it.
+
+    An explicit ``mermaid_inline_puppeteer_config`` wins; otherwise a minimal
+    config is generated, adding ``executablePath`` from
+    ``PUPPETEER_EXECUTABLE_PATH`` or a discovered cached Chrome.
+    """
+    configured = app.config.mermaid_inline_puppeteer_config
+    if configured:
+        return pathlib.Path(configured)
+    data: dict[str, t.Any] = {
+        "args": ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+    }
+    executable = os.environ.get("PUPPETEER_EXECUTABLE_PATH") or _discover_chrome()
+    if executable:
+        data["executablePath"] = executable
+    out = tmpdir / "puppeteer.json"
+    out.write_text(json.dumps(data), encoding="utf-8")
+    return out
+
+
+def _render(app: Sphinx, source: str, theme: str) -> str:
+    """Render ``source`` to an SVG string via ``mmdc`` for the given theme."""
+    mmdc = _resolve_mmdc(app)
+    if mmdc is None:
+        msg = (
+            "mmdc (@mermaid-js/mermaid-cli) not found; install it in the docs "
+            "toolchain or set the mermaid_inline_cmd config value"
+        )
+        raise MermaidRendererMissing(msg)
+    with tempfile.TemporaryDirectory(prefix="mermaid-inline-") as td:
+        tmpdir = pathlib.Path(td)
+        in_file = tmpdir / "diagram.mmd"
+        out_file = tmpdir / "diagram.svg"
+        in_file.write_text(source, encoding="utf-8")
+        argv = [
+            *mmdc,
+            "-i",
+            str(in_file),
+            "-o",
+            str(out_file),
+            "-b",
+            "transparent",
+            "-t",
+            theme,
+            "-p",
+            str(_puppeteer_config_file(app, tmpdir)),
+        ]
+        try:
+            subprocess.run(
+                argv,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+        except FileNotFoundError as exc:  # mmdc vanished between resolve and run
+            raise MermaidRendererMissing(str(exc)) from exc
+        except subprocess.SubprocessError as exc:
+            stderr = getattr(exc, "stderr", "") or ""
+            msg = f"mmdc failed: {exc}\n{stderr}"
+            raise MermaidRenderError(msg) from exc
+        if not out_file.is_file():
+            msg = "mmdc produced no SVG output"
+            raise MermaidRenderError(msg)
+        return out_file.read_text(encoding="utf-8")
+
+
+def _render_cached(app: Sphinx, source: str, theme: str) -> str:
+    """Return a rendered SVG, reading/writing a content-hashed on-disk cache.
+
+    The cache lives outside ``_build`` (under the confdir) so it survives the
+    ``rm -rf docs/_build`` that precedes a full build.
+    """
+    digest = _diagram_digest(source, theme)
+    cache_dir = pathlib.Path(app.confdir) / "_mermaid_cache"
+    cache_file = cache_dir / f"{digest}.svg"
+    if cache_file.is_file():
+        return cache_file.read_text(encoding="utf-8")
+    svg = _render(app, source, theme)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(svg, encoding="utf-8")
+    return svg
+
+
+def _warn_render_failure(node: nodes.Node, exc: MermaidError) -> None:
+    """Emit a single build warning when rendering is unavailable or fails."""
+    global _render_warned
+    if _render_warned:
+        return
+    _render_warned = True
+    logger.warning(
+        "mermaid render unavailable; emitting diagram source as text: %s",
+        exc,
+        location=node,
+    )
+
+
+def html_visit_mermaid_inline(self: HTML5Translator, node: mermaid_inline) -> None:
+    """Render the diagram and append dual light/dark inline SVG, then skip."""
+    source: str = node["mermaid_source"]
+    app = self.builder.app
+    try:
+        light = _render_cached(app, source, _THEME_LIGHT)
+        dark = _render_cached(app, source, _THEME_DARK)
+    except MermaidError as exc:
+        _warn_render_failure(node, exc)
+        self.body.append(
+            '<pre class="gp-diagram-fallback">' + html.escape(source) + "</pre>",
+        )
+        raise nodes.SkipNode from None
+
+    digest = _diagram_digest(source, "")
+    light = _normalize_svg(light, svg_id=_svg_element_id(digest, _THEME_LIGHT))
+    dark = _normalize_svg(dark, svg_id=_svg_element_id(digest, _THEME_DARK))
+
+    caption: str = node.get("caption", "")
+    alt = node.get("alt", "") or caption
+    aria = f' aria-label="{html.escape(alt, quote=True)}"' if alt else ""
+    ids: list[str] = node.get("ids", [])
+    fig_id = f' id="{ids[0]}"' if ids else ""
+
+    parts = [
+        f'<figure class="gp-diagram-wrapper"{fig_id}>',
+        f'<div class="gp-diagram gp-diagram--light" role="img"{aria}>{light}</div>',
+        (
+            '<div class="gp-diagram gp-diagram--dark" role="img" '
+            f'aria-hidden="true">{dark}</div>'
+        ),
+    ]
+    if caption:
+        parts.append(f"<figcaption>{html.escape(caption)}</figcaption>")
+    parts.append("</figure>")
+    self.body.append("".join(parts))
+    raise nodes.SkipNode
+
+
+def _depart_mermaid_inline(self: HTML5Translator, node: mermaid_inline) -> None:
+    """No-op; :func:`html_visit_mermaid_inline` raises ``SkipNode``."""
+
+
+def setup(app: Sphinx) -> dict[str, t.Any]:
+    """Register the directive, node, config values, and stylesheet."""
+    app.add_node(
+        mermaid_inline,
+        html=(html_visit_mermaid_inline, _depart_mermaid_inline),
+    )
+    app.add_directive("mermaid", MermaidDirective)
+    app.add_config_value("mermaid_inline_cmd", "", "env")
+    app.add_config_value("mermaid_inline_puppeteer_config", "", "env")
+    app.add_css_file("css/gp-diagram.css")
+    return {
+        "version": "0.1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_ext/mermaid_inline.py
+++ b/docs/_ext/mermaid_inline.py
@@ -358,12 +358,16 @@ def _puppeteer_config_file(app: Sphinx, tmpdir: pathlib.Path) -> pathlib.Path:
 def _mermaid_config(theme: str) -> dict[str, t.Any]:
     """Return the mermaid ``-c`` config: base theme + furo palette + themeCSS.
 
+    ``block.padding: 0`` tiles block-beta panes contiguously, like a tmux
+    window; other diagram types ignore the ``block`` key.
+
     >>> cfg = _mermaid_config("light")
-    >>> cfg["theme"], "themeVariables" in cfg, "themeCSS" in cfg
-    ('base', True, True)
+    >>> cfg["theme"], "themeVariables" in cfg, cfg["block"]["padding"]
+    ('base', True, 0)
     """
     return {
         "theme": "base",
+        "block": {"padding": 0},
         "themeVariables": _PALETTES[theme],
         "themeCSS": _theme_css(theme),
     }

--- a/docs/_ext/mermaid_inline.py
+++ b/docs/_ext/mermaid_inline.py
@@ -47,11 +47,46 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 #: Bump to invalidate the on-disk render cache when render arguments change.
-_RENDER_VERSION = "mmdc11-svg-v1"
+_RENDER_VERSION = "mmdc11-furo-svg-v1"
 
-#: mermaid theme presets used for the two inlined variants.
-_THEME_LIGHT = "default"
+#: Logical names for the two inlined variants (cache key, SVG id, CSS class).
+_THEME_LIGHT = "light"
 _THEME_DARK = "dark"
+
+#: System font stack matching gp-furo's body font (gp-furo-tokens --font-stack).
+_FONT_STACK = (
+    "-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif"
+)
+
+#: mermaid ``base``-theme variables mapped to gp-furo's light/dark colour tokens
+#: (gp-furo-tokens: light.ts / dark.ts) so diagrams match the site palette.
+#: Colour does not affect layout, so both variants share geometry.
+_PALETTES: dict[str, dict[str, str]] = {
+    _THEME_LIGHT: {
+        "primaryColor": "#f8f9fb",
+        "primaryBorderColor": "#0a4bff",
+        "primaryTextColor": "#000000",
+        "lineColor": "#6b6f76",
+        "textColor": "#000000",
+        "background": "#ffffff",
+        "edgeLabelBackground": "#f8f9fb",
+        "secondaryColor": "#ffffff",
+        "tertiaryColor": "#f8f9fb",
+        "fontFamily": _FONT_STACK,
+    },
+    _THEME_DARK: {
+        "primaryColor": "#1a1c1e",
+        "primaryBorderColor": "#3d94ff",
+        "primaryTextColor": "#cfd0d0",
+        "lineColor": "#81868d",
+        "textColor": "#cfd0d0",
+        "background": "#131416",
+        "edgeLabelBackground": "#1a1c1e",
+        "secondaryColor": "#131416",
+        "tertiaryColor": "#1a1c1e",
+        "fontFamily": _FONT_STACK,
+    },
+}
 
 #: mermaid hardcodes this id on every rendered SVG and scopes its CSS and
 #: arrowhead markers to it; it is rewritten per diagram+theme to avoid
@@ -240,7 +275,13 @@ def _render(app: Sphinx, source: str, theme: str) -> str:
         tmpdir = pathlib.Path(td)
         in_file = tmpdir / "diagram.mmd"
         out_file = tmpdir / "diagram.svg"
+        config_file = tmpdir / "config.json"
         in_file.write_text(source, encoding="utf-8")
+        config: dict[str, t.Any] = {
+            "theme": "base",
+            "themeVariables": _PALETTES[theme],
+        }
+        config_file.write_text(json.dumps(config), encoding="utf-8")
         argv = [
             *mmdc,
             "-i",
@@ -249,8 +290,8 @@ def _render(app: Sphinx, source: str, theme: str) -> str:
             str(out_file),
             "-b",
             "transparent",
-            "-t",
-            theme,
+            "-c",
+            str(config_file),
             "-p",
             str(_puppeteer_config_file(app, tmpdir)),
         ]

--- a/docs/_ext/mermaid_inline.py
+++ b/docs/_ext/mermaid_inline.py
@@ -48,7 +48,7 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 #: Bump to invalidate the on-disk render cache when render arguments change.
-_RENDER_VERSION = "mmdc11-furo-svg-v3"
+_RENDER_VERSION = "mmdc11-furo-svg-v4"
 
 #: Logical names for the two inlined variants (cache key, SVG id, CSS class).
 _THEME_LIGHT = "light"
@@ -97,11 +97,17 @@ def _theme_css(theme: str) -> str:
     """Return the CSS injected into a rendered SVG for the given theme.
 
     Renders ``:::cmd`` nodes in a monospace font so commands read as code;
-    centres node labels (the build's headless Chrome may lack the exact mono
-    face, so the measured box can be wider than the on-page text, which would
-    otherwise fall left); and collapses mermaid's three stacked edge-label
-    backgrounds into one padded chip in the theme's label colour. ``white-space:
-    normal`` lets a padded label wrap instead of overflowing its measured box.
+    centres each node label in its box; and collapses mermaid's three stacked
+    edge-label backgrounds into one padded chip in the theme's label colour.
+
+    Centering uses ``display: table`` + ``margin: 0 auto`` rather than a width
+    or flex rule: the build's headless Chrome may render the font at a different
+    width than the visitor's browser, leaving the shrink-to-fit ``table-cell``
+    narrower than the measured box (so it falls left), but anything that
+    *resizes* the label corrupts mermaid's build-time measurement pass. A table
+    with auto margins re-centres without changing the measured size.
+    ``white-space: normal`` lets a padded edge label wrap instead of
+    overflowing its measured box.
 
     >>> "monospace" in _theme_css("light")
     True
@@ -112,6 +118,10 @@ def _theme_css(theme: str) -> str:
     return (
         ".cmd .nodeLabel { font-family: " + _MONO_STACK + " !important; }"
         " .nodeLabel, .nodeLabel p { text-align: center !important; }"
+        " .node foreignObject > div {"
+        " display: table !important;"
+        " margin: 0 auto !important;"
+        " }"
         " .edgeLabel rect { opacity: 0 !important; }"
         " .labelBkg { background: transparent !important; }"
         " .edgeLabel { background: transparent !important; }"
@@ -151,21 +161,31 @@ class mermaid_inline(nodes.General, nodes.Element):
     """Doctree node carrying mermaid source until the HTML write phase."""
 
 
-def _diagram_digest(source: str, theme: str, *, version: str = _RENDER_VERSION) -> str:
+def _diagram_digest(
+    source: str,
+    theme: str,
+    *,
+    version: str = _RENDER_VERSION,
+    extra: str = "",
+) -> str:
     """Return a stable content hash that keys the render cache.
 
-    The hash covers the render version, the theme, and the source, so light and
-    dark variants cache separately and a render-argument change busts the cache.
+    The hash covers the render version, the theme, the source, and ``extra``
+    (the full mermaid config JSON) — so light and dark variants cache
+    separately and any styling change, not just a source change, busts the
+    cache.
 
     >>> a = _diagram_digest("flowchart LR a-->b", "default")
     >>> a == _diagram_digest("flowchart LR a-->b", "default")
     True
     >>> a != _diagram_digest("flowchart LR a-->b", "dark")
     True
+    >>> a != _diagram_digest("flowchart LR a-->b", "default", extra="{}")
+    True
     >>> len(a)
     40
     """
-    payload = f"{version}\x00{theme}\x00{source}"
+    payload = f"{version}\x00{theme}\x00{extra}\x00{source}"
     return hashlib.sha1(payload.encode("utf-8")).hexdigest()
 
 
@@ -320,8 +340,22 @@ def _puppeteer_config_file(app: Sphinx, tmpdir: pathlib.Path) -> pathlib.Path:
     return out
 
 
-def _render(app: Sphinx, source: str, theme: str) -> str:
-    """Render ``source`` to an SVG string via ``mmdc`` for the given theme."""
+def _mermaid_config(theme: str) -> dict[str, t.Any]:
+    """Return the mermaid ``-c`` config: base theme + furo palette + themeCSS.
+
+    >>> cfg = _mermaid_config("light")
+    >>> cfg["theme"], "themeVariables" in cfg, "themeCSS" in cfg
+    ('base', True, True)
+    """
+    return {
+        "theme": "base",
+        "themeVariables": _PALETTES[theme],
+        "themeCSS": _theme_css(theme),
+    }
+
+
+def _render(app: Sphinx, source: str, config_json: str) -> str:
+    """Render ``source`` to an SVG string via ``mmdc`` using ``config_json``."""
     mmdc = _resolve_mmdc(app)
     if mmdc is None:
         msg = (
@@ -335,12 +369,7 @@ def _render(app: Sphinx, source: str, theme: str) -> str:
         out_file = tmpdir / "diagram.svg"
         config_file = tmpdir / "config.json"
         in_file.write_text(source, encoding="utf-8")
-        config: dict[str, t.Any] = {
-            "theme": "base",
-            "themeVariables": _PALETTES[theme],
-            "themeCSS": _theme_css(theme),
-        }
-        config_file.write_text(json.dumps(config), encoding="utf-8")
+        config_file.write_text(config_json, encoding="utf-8")
         argv = [
             *mmdc,
             "-i",
@@ -380,12 +409,13 @@ def _render_cached(app: Sphinx, source: str, theme: str) -> str:
     The cache lives outside ``_build`` (under the confdir) so it survives the
     ``rm -rf docs/_build`` that precedes a full build.
     """
-    digest = _diagram_digest(source, theme)
+    config_json = json.dumps(_mermaid_config(theme), sort_keys=True)
+    digest = _diagram_digest(source, theme, extra=config_json)
     cache_dir = pathlib.Path(app.confdir) / "_mermaid_cache"
     cache_file = cache_dir / f"{digest}.svg"
     if cache_file.is_file():
         return cache_file.read_text(encoding="utf-8")
-    svg = _render(app, source, theme)
+    svg = _render(app, source, config_json)
     cache_dir.mkdir(parents=True, exist_ok=True)
     cache_file.write_text(svg, encoding="utf-8")
     return svg

--- a/docs/_ext/mermaid_inline.py
+++ b/docs/_ext/mermaid_inline.py
@@ -139,7 +139,11 @@ def _theme_css(theme: str) -> str:
 #: duplicate-id collisions when both variants are inlined on one page.
 _MERMAID_DEFAULT_ID = "my-svg"
 
-_VIEWBOX_RE = re.compile(r'viewBox="0 0 ([\d.]+) ([\d.]+)"')
+# Width/height are the 3rd/4th viewBox numbers of the ROOT <svg> tag. Anchoring
+# to ``<svg ... >`` (no ``>`` in between) avoids matching an inner element's
+# viewBox, and the min-x/min-y may be negative (block diagrams use e.g.
+# ``viewBox="-5 -97 148 194"``).
+_VIEWBOX_RE = re.compile(r'<svg\b[^>]*?\bviewBox="-?[\d.]+ -?[\d.]+ ([\d.]+) ([\d.]+)"')
 
 #: Guards the "renderer missing/failed" warning so it fires once, not per node.
 _render_warned = False
@@ -226,6 +230,17 @@ def _normalize_svg(svg: str, *, svg_id: str) -> str:
     >>> "max-width" in out
     False
     >>> 'id="mermaid-abc-light"' in out and "url(#mermaid-abc-light_end)" in out
+    True
+
+    Block diagrams use a negative viewBox origin and carry inner viewBoxes;
+    the root's width/height (3rd/4th numbers) win, not an inner ``0 0 10 10``:
+
+    >>> block = (
+    ...     '<svg id="my-svg" width="100%" viewBox="-5 -97 148 194">'
+    ...     '<marker viewBox="0 0 10 10"/></svg>'
+    ... )
+    >>> out = _normalize_svg(block, svg_id="x")
+    >>> 'width="148"' in out and 'height="194"' in out
     True
     """
     svg = svg.replace(_MERMAID_DEFAULT_ID, svg_id)

--- a/docs/_ext/mermaid_inline.py
+++ b/docs/_ext/mermaid_inline.py
@@ -32,6 +32,7 @@ import pathlib
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import typing as t
 
@@ -210,17 +211,39 @@ class MermaidDirective(SphinxDirective):
         return [node]
 
 
+def _chrome_glob(platform: str) -> str:
+    """Return the puppeteer-cache glob for Chrome on the given ``sys.platform``.
+
+    Puppeteer lays the binary out per platform under ``chrome/<build>/``.
+
+    >>> _chrome_glob("linux")
+    '*/chrome-linux64/chrome'
+    >>> _chrome_glob("win32")
+    '*/chrome-win64/chrome.exe'
+    >>> _chrome_glob("darwin").startswith("*/chrome-mac-")
+    True
+    """
+    if platform.startswith("win"):
+        return "*/chrome-win64/chrome.exe"
+    if platform == "darwin":
+        return (
+            "*/chrome-mac-*/Google Chrome for Testing.app"
+            "/Contents/MacOS/Google Chrome for Testing"
+        )
+    return "*/chrome-linux64/chrome"
+
+
 def _discover_chrome() -> str | None:
     """Return a Chrome installed by ``puppeteer browsers install``, if any.
 
     Puppeteer's automatic resolution can miss the cached browser (its cache dir
     is computed relative to the install location); pointing ``executablePath`` at
-    the discovered binary sidesteps that. Linux/WSL layout only.
+    the discovered binary sidesteps that.
     """
     cache = pathlib.Path.home() / ".cache" / "puppeteer" / "chrome"
     if not cache.is_dir():
         return None
-    candidates = sorted(cache.glob("*/chrome-linux64/chrome"))
+    candidates = sorted(cache.glob(_chrome_glob(sys.platform)))
     return str(candidates[-1]) if candidates else None
 
 

--- a/docs/_ext/mermaid_inline.py
+++ b/docs/_ext/mermaid_inline.py
@@ -48,7 +48,7 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 #: Bump to invalidate the on-disk render cache when render arguments change.
-_RENDER_VERSION = "mmdc11-furo-svg-v2"
+_RENDER_VERSION = "mmdc11-furo-svg-v3"
 
 #: Logical names for the two inlined variants (cache key, SVG id, CSS class).
 _THEME_LIGHT = "light"
@@ -89,19 +89,40 @@ _PALETTES: dict[str, dict[str, str]] = {
     },
 }
 
-#: Extra CSS injected into every rendered SVG (theme-agnostic). Nodes tagged
-#: ``:::cmd`` render in a monospace font so commands read as code; edge labels
-#: get padding. ``white-space: normal`` lets a padded label keep wrapping
-#: instead of overflowing the box mermaid measured for it.
+#: Monospace stack matching gp-furo's ``--font-stack--monospace``.
 _MONO_STACK = "'SFMono-Regular', Menlo, Consolas, Monaco, 'Liberation Mono', monospace"
-_THEME_CSS = (
-    ".cmd .nodeLabel { font-family: " + _MONO_STACK + " !important; }"
-    " .edgeLabels .labelBkg {"
-    " padding: 3px 10px !important;"
-    " white-space: normal !important;"
-    " border-radius: 4px;"
-    " }"
-)
+
+
+def _theme_css(theme: str) -> str:
+    """Return the CSS injected into a rendered SVG for the given theme.
+
+    Renders ``:::cmd`` nodes in a monospace font so commands read as code;
+    centres node labels (the build's headless Chrome may lack the exact mono
+    face, so the measured box can be wider than the on-page text, which would
+    otherwise fall left); and collapses mermaid's three stacked edge-label
+    backgrounds into one padded chip in the theme's label colour. ``white-space:
+    normal`` lets a padded label wrap instead of overflowing its measured box.
+
+    >>> "monospace" in _theme_css("light")
+    True
+    >>> "#f8f9fb" in _theme_css("light")
+    True
+    """
+    bg = _PALETTES[theme]["edgeLabelBackground"]
+    return (
+        ".cmd .nodeLabel { font-family: " + _MONO_STACK + " !important; }"
+        " .nodeLabel, .nodeLabel p { text-align: center !important; }"
+        " .edgeLabel rect { opacity: 0 !important; }"
+        " .labelBkg { background: transparent !important; }"
+        " .edgeLabel { background: transparent !important; }"
+        " .edgeLabel p {"
+        " background: " + bg + " !important;"
+        " padding: 3px 10px !important;"
+        " border-radius: 4px !important;"
+        " white-space: normal !important;"
+        " }"
+    )
+
 
 #: mermaid hardcodes this id on every rendered SVG and scopes its CSS and
 #: arrowhead markers to it; it is rewritten per diagram+theme to avoid
@@ -317,7 +338,7 @@ def _render(app: Sphinx, source: str, theme: str) -> str:
         config: dict[str, t.Any] = {
             "theme": "base",
             "themeVariables": _PALETTES[theme],
-            "themeCSS": _THEME_CSS,
+            "themeCSS": _theme_css(theme),
         }
         config_file.write_text(json.dumps(config), encoding="utf-8")
         argv = [

--- a/docs/_ext/tmux_layout.py
+++ b/docs/_ext/tmux_layout.py
@@ -1,0 +1,366 @@
+"""Render tmux window layouts as inline SVG that looks like a terminal.
+
+A ``tmux-layout`` directive declares a screen size and a tmux layout; the panes
+tile the screen with no gaps, exactly the way tmux splits a window. Each pane's
+shell commands are drawn top-left in a fixed-width font and syntax-highlighted
+with Pygments, so the diagram reads like the real terminal. This is the
+spiritual successor to the old ``aafig`` ASCII-art boxes, but tmux-aware.
+
+Authoring — panes are separated by a ``---`` line, each holding that pane's
+commands::
+
+    :::{tmux-layout}
+    :size: 64x18
+    :layout: even-vertical
+
+    echo 'did you know'
+    echo 'you can inline'
+    ---
+    echo 'single commands'
+    ---
+    echo 'for panes'
+    :::
+
+``:layout:`` is one of tmux's arrangements: ``even-vertical`` (default),
+``even-horizontal``, ``main-vertical``, ``main-horizontal``, ``tiled``.
+
+Output is a single inline ``<svg>`` whose colours are CSS custom properties
+(``gp-tmux-layout.css``), so it paints with the page, adapts to light/dark via
+``body[data-theme]`` with no JavaScript and no second render, and rides
+gp-sphinx SPA swaps as live DOM — without the headless-browser dependency the
+mermaid pipeline needs.
+"""
+
+from __future__ import annotations
+
+import html
+import typing as t
+
+from docutils import nodes
+from pygments.lexers.shell import BashLexer
+from pygments.token import STANDARD_TYPES
+from sphinx.util import logging
+from sphinx.util.docutils import SphinxDirective
+
+if t.TYPE_CHECKING:
+    from sphinx.application import Sphinx
+    from sphinx.writers.html5 import HTML5Translator
+
+logger = logging.getLogger(__name__)
+
+#: Pixels per tmux character cell (column width, row height). The viewBox is in
+#: these pixels, so at the SVG's intrinsic size one unit is one CSS pixel and
+#: the text renders at the page's code font size, like a real code block.
+_CW = 8.0
+_CH = 17.0
+#: Padding (px) between a pane edge and its text.
+_PAD = 6.0
+#: Approx. font ascent (px) for placing the first baseline below the padding.
+_FONT = 12.0
+#: Baseline-to-baseline distance (px) for stacked command lines.
+_LINE_H = 17.0
+#: A simple shell prompt prefixed to each command line. The ``gp`` class is
+#: Pygments' Generic.Prompt, so it takes the theme's prompt colour (like the
+#: ``$`` in the site's console blocks).
+_PROMPT = '<tspan class="gp">❯ </tspan>'  # noqa: RUF001
+
+_LAYOUTS = (
+    "even-vertical",
+    "even-horizontal",
+    "main-vertical",
+    "main-horizontal",
+    "tiled",
+)
+_LEXER = BashLexer()
+
+
+class TmuxLayoutError(ValueError):
+    """A tmux-layout directive could not be rendered."""
+
+
+class Rect(t.NamedTuple):
+    """A pane rectangle in character-cell coordinates."""
+
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+def _even(n: int, w: float, h: float, *, vertical: bool) -> list[Rect]:
+    """Split the screen into ``n`` equal panes, filling it completely.
+
+    >>> [round(r.h, 2) for r in _even(2, 80, 24, vertical=True)]
+    [12.0, 12.0]
+    >>> [round(r.w, 2) for r in _even(2, 80, 24, vertical=False)]
+    [40.0, 40.0]
+    """
+    rects = []
+    for i in range(n):
+        if vertical:
+            y0, y1 = i * h / n, (i + 1) * h / n
+            rects.append(Rect(0.0, y0, w, y1 - y0))
+        else:
+            x0, x1 = i * w / n, (i + 1) * w / n
+            rects.append(Rect(x0, 0.0, x1 - x0, h))
+    return rects
+
+
+def _main(
+    n: int, w: float, h: float, *, vertical: bool, ratio: float = 0.5
+) -> list[Rect]:
+    """One main pane plus the rest split evenly beside/below it.
+
+    >>> r = _main(3, 80, 24, vertical=True)
+    >>> (round(r[0].w), round(r[1].x), len(r))
+    (40, 40, 3)
+    """
+    if n == 1:
+        return [Rect(0.0, 0.0, w, h)]
+    if vertical:
+        mw = w * ratio
+        rects = [Rect(0.0, 0.0, mw, h)]
+        rects += [
+            Rect(mw + r.x, r.y, r.w, r.h)
+            for r in _even(n - 1, w - mw, h, vertical=True)
+        ]
+    else:
+        mh = h * ratio
+        rects = [Rect(0.0, 0.0, w, mh)]
+        rects += [
+            Rect(r.x, mh + r.y, r.w, r.h)
+            for r in _even(n - 1, w, h - mh, vertical=False)
+        ]
+    return rects
+
+
+def _tiled(n: int, w: float, h: float) -> list[Rect]:
+    """Tile ``n`` panes into a grid that fills the screen (tmux ``tiled``).
+
+    >>> len(_tiled(4, 80, 24)), round(_tiled(4, 80, 24)[0].w)
+    (4, 40)
+    """
+    rows = cols = 1
+    while rows * cols < n:
+        rows += 1
+        if rows * cols < n:
+            cols += 1
+    rects = []
+    for i in range(n):
+        r, c = divmod(i, cols)
+        in_row = cols if r < rows - 1 else n - cols * (rows - 1)
+        x0, x1 = c * w / in_row, (c + 1) * w / in_row
+        y0, y1 = r * h / rows, (r + 1) * h / rows
+        rects.append(Rect(x0, y0, x1 - x0, y1 - y0))
+    return rects
+
+
+def arrange(layout: str, n: int, w: int, h: int) -> list[Rect]:
+    """Return ``n`` pane rectangles filling a ``w`` x ``h`` screen.
+
+    >>> [round(r.h) for r in arrange("even-vertical", 3, 80, 24)]
+    [8, 8, 8]
+    >>> len(arrange("tiled", 4, 80, 24))
+    4
+    """
+    if n < 1:
+        msg = "a tmux layout needs at least one pane"
+        raise TmuxLayoutError(msg)
+    if n == 1:
+        return [Rect(0.0, 0.0, float(w), float(h))]
+    if layout == "even-vertical":
+        return _even(n, w, h, vertical=True)
+    if layout == "even-horizontal":
+        return _even(n, w, h, vertical=False)
+    if layout == "main-vertical":
+        return _main(n, w, h, vertical=True)
+    if layout == "main-horizontal":
+        return _main(n, w, h, vertical=False)
+    if layout == "tiled":
+        return _tiled(n, w, h)
+    msg = f"unknown layout {layout!r}; expected one of {', '.join(_LAYOUTS)}"
+    raise TmuxLayoutError(msg)
+
+
+def _highlight(line: str) -> str:
+    """Return a shell command as Pygments-classed ``<tspan>``s.
+
+    The command name (a shell builtin like ``echo``/``pwd``) is left in the
+    default text colour, like a freshly typed command; strings, comments, and
+    the like keep their Pygments classes.
+
+    >>> 'class="nb"' in _highlight("echo hello")
+    False
+    >>> 'class="s1"' in _highlight("echo 'hi'")
+    True
+    >>> "&#x27;hi&#x27;" in _highlight("echo 'hi'")
+    True
+    """
+    spans = []
+    for token, value in _LEXER.get_tokens(line):
+        text = value.rstrip("\n")
+        if not text:
+            continue
+        css = STANDARD_TYPES.get(token, "")
+        if css == "nb":  # command builtins (echo, pwd) keep the default colour
+            css = ""
+        escaped = html.escape(text)
+        spans.append(f'<tspan class="{css}">{escaped}</tspan>' if css else escaped)
+    return "".join(spans)
+
+
+def _parse_size(size: str) -> tuple[int, int]:
+    """Parse a ``WxH`` screen size.
+
+    >>> _parse_size("64x18")
+    (64, 18)
+    """
+    try:
+        w_str, h_str = size.lower().split("x", 1)
+        return int(w_str), int(h_str)
+    except ValueError as exc:
+        msg = f"invalid size {size!r}; expected WxH (e.g. 80x24)"
+        raise TmuxLayoutError(msg) from exc
+
+
+def render_layout(panes: list[list[str]], layout: str, size: tuple[int, int]) -> str:
+    """Render panes (each a list of command lines) to an inline ``<svg>``.
+
+    >>> svg = render_layout([["echo a"], ["echo b"]], "even-vertical", (40, 12))
+    >>> svg.startswith("<svg") and svg.count('class="pane"')
+    2
+    """
+    w, h = size
+    rects = arrange(layout, len(panes), w, h)
+    vb_w, vb_h = w * _CW, h * _CH
+    parts = [
+        f'<svg class="gp-tmux-layout" viewBox="0 0 {vb_w:g} {vb_h:g}" '
+        f'width="{vb_w:g}" height="{vb_h:g}" role="img" '
+        'xmlns="http://www.w3.org/2000/svg">',
+    ]
+    # Pane fills first; the window border and single dividers go on top so a
+    # shared edge is one line, not two abutting pane strokes.
+    parts.extend(
+        f'<rect class="pane" x="{rect.x * _CW:g}" y="{rect.y * _CH:g}" '
+        f'width="{rect.w * _CW:g}" height="{rect.h * _CH:g}"/>'
+        for rect in rects
+    )
+    for rect in rects:
+        right, bottom = rect.x + rect.w, rect.y + rect.h
+        if right < w:  # internal vertical divider
+            parts.append(
+                f'<line class="divider" x1="{right * _CW:g}" y1="{rect.y * _CH:g}" '
+                f'x2="{right * _CW:g}" y2="{bottom * _CH:g}"/>',
+            )
+        if bottom < h:  # internal horizontal divider
+            parts.append(
+                f'<line class="divider" x1="{rect.x * _CW:g}" y1="{bottom * _CH:g}" '
+                f'x2="{(rect.x + rect.w) * _CW:g}" y2="{bottom * _CH:g}"/>',
+            )
+    parts.append(
+        f'<rect class="window" x="0" y="0" width="{vb_w:g}" height="{vb_h:g}"/>',
+    )
+    # Pygments colours come from furo's own `.highlight` rules (theme-matched,
+    # light/dark) via `fill: currentColor`; a <g> ignores its background.
+    parts.append('<g class="highlight">')
+    for rect, commands in zip(rects, panes, strict=True):
+        tx = rect.x * _CW + _PAD
+        baseline = rect.y * _CH + _PAD + _FONT
+        for i, line in enumerate(commands):
+            body = _highlight(line)
+            if not body:
+                continue
+            ty = baseline + i * _LINE_H
+            parts.append(
+                f'<text class="cmd" x="{tx:g}" y="{ty:g}" '
+                f'xml:space="preserve">{_PROMPT}{body}</text>',
+            )
+    parts.append("</g></svg>")
+    return "".join(parts)
+
+
+def _split_panes(content: list[str]) -> list[list[str]]:
+    """Split directive content on ``---`` lines into per-pane command lists.
+
+    >>> _split_panes(["echo a", "echo b", "---", "echo c"])
+    [['echo a', 'echo b'], ['echo c']]
+    """
+    panes: list[list[str]] = [[]]
+    for line in content:
+        if line.strip() == "---":
+            panes.append([])
+        else:
+            panes[-1].append(line.rstrip())
+    return [
+        [line for line in pane if line.strip()]
+        for pane in panes
+        if any(p.strip() for p in pane)
+    ]
+
+
+class tmux_layout(nodes.General, nodes.Element):
+    """Doctree node carrying a rendered tmux-layout SVG."""
+
+
+class TmuxLayoutDirective(SphinxDirective):
+    """Render a declared tmux layout as an inline, terminal-styled SVG."""
+
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 0
+    option_spec: t.ClassVar[dict[str, t.Callable[[str], t.Any]]] = {
+        "size": lambda x: x,
+        "layout": lambda x: x,
+        "caption": lambda x: x,
+    }
+
+    def run(self) -> list[nodes.Node]:
+        """Return a :class:`tmux_layout` node with the rendered SVG."""
+        panes = _split_panes(list(self.content))
+        if not panes:
+            warning = self.state.document.reporter.warning(
+                "tmux-layout directive has no panes",
+                line=self.lineno,
+            )
+            return [warning]
+        layout = self.options.get("layout", "even-vertical")
+        try:
+            svg = render_layout(
+                panes, layout, _parse_size(self.options.get("size", "80x24"))
+            )
+        except TmuxLayoutError as exc:
+            logger.warning("invalid tmux layout: %s", exc, location=self.get_location())
+            return [
+                nodes.literal_block("\n".join(self.content), "\n".join(self.content))
+            ]
+        node = tmux_layout()
+        node["svg"] = svg
+        node["caption"] = self.options.get("caption", "")
+        return [node]
+
+
+def html_visit_tmux_layout(self: HTML5Translator, node: tmux_layout) -> None:
+    """Append the inline SVG (wrapped in a figure) and skip the node."""
+    caption = node.get("caption", "")
+    parts = [f'<figure class="gp-tmux-layout-wrapper">{node["svg"]}']
+    if caption:
+        parts.append(f"<figcaption>{html.escape(caption)}</figcaption>")
+    parts.append("</figure>")
+    self.body.append("".join(parts))
+    raise nodes.SkipNode
+
+
+def _depart_tmux_layout(self: HTML5Translator, node: tmux_layout) -> None:
+    """No-op; :func:`html_visit_tmux_layout` raises ``SkipNode``."""
+
+
+def setup(app: Sphinx) -> dict[str, t.Any]:
+    """Register the directive, node, and stylesheet."""
+    app.add_node(tmux_layout, html=(html_visit_tmux_layout, _depart_tmux_layout))
+    app.add_directive("tmux-layout", TmuxLayoutDirective)
+    app.add_css_file("css/gp-tmux-layout.css")
+    return {
+        "version": "0.1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_static/css/gp-diagram.css
+++ b/docs/_static/css/gp-diagram.css
@@ -1,0 +1,72 @@
+/*
+ * Build-time mermaid diagrams (docs/_ext/mermaid_inline.py).
+ *
+ * Each diagram is inlined twice — a light and a dark SVG — and this stylesheet
+ * shows exactly one. Mermaid bakes literal colours into an id-scoped,
+ * !important <style>, so a single SVG cannot be re-themed by CSS; the two
+ * variants share identical geometry, so toggling display never shifts layout.
+ */
+
+.gp-diagram-wrapper {
+  margin: 1.5rem 0;
+  /* Wide diagrams scroll within the column instead of overflowing it. */
+  overflow-x: auto;
+}
+
+.gp-diagram svg {
+  /* Intrinsic width/height/viewBox are set at build time; these let the
+     diagram scale down on narrow columns while keeping its aspect ratio,
+     so there is no layout shift. */
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+.gp-diagram figcaption,
+.gp-diagram-wrapper > figcaption {
+  text-align: center;
+  font-size: 0.9em;
+  margin-top: 0.5rem;
+}
+
+/*
+ * Three-state theme toggle, mirroring Furo's light/dark logo switching:
+ *   - default: light variant,
+ *   - explicit dark (body[data-theme="dark"]): dark variant,
+ *   - system dark with no explicit choice: dark variant.
+ * data-theme is set on <body> before first paint and <body> is never swapped
+ * during SPA navigation, so the correct variant shows immediately and stays
+ * correct across page swaps with no JavaScript.
+ */
+.gp-diagram--light {
+  display: block;
+}
+
+.gp-diagram--dark {
+  display: none;
+}
+
+body[data-theme="dark"] .gp-diagram--light {
+  display: none;
+}
+
+body[data-theme="dark"] .gp-diagram--dark {
+  display: block;
+}
+
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) .gp-diagram--light {
+    display: none;
+  }
+
+  body:not([data-theme="light"]) .gp-diagram--dark {
+    display: block;
+  }
+}
+
+/* Shown only when mmdc is unavailable at build time (degraded fallback). */
+.gp-diagram-fallback {
+  white-space: pre;
+  overflow-x: auto;
+}

--- a/docs/_static/css/gp-tmux-layout.css
+++ b/docs/_static/css/gp-tmux-layout.css
@@ -1,0 +1,74 @@
+/*
+ * tmux window layouts (docs/_ext/tmux_layout.py).
+ *
+ * Plain inline SVG: it inherits furo's CSS custom properties and adapts to
+ * light/dark via body[data-theme] with no JavaScript and no second render.
+ *
+ * Shell highlighting reuses furo's own Pygments rules: the command text is
+ * wrapped in <g class="highlight">, so `.highlight .nb`, `.highlight .gp`
+ * (the prompt), etc. apply, and SVG <text> takes its colour from `color` via
+ * `fill: currentColor` — so the panes match the site's console blocks exactly,
+ * font and colours, in both light and dark. The viewBox is in pixels (one tmux
+ * cell = _CW x _CH), so at intrinsic size the text renders at the code font
+ * size.
+ */
+
+.gp-tmux-layout-wrapper {
+  margin: 1.5rem 0;
+  text-align: center;
+}
+
+.gp-tmux-layout {
+  max-width: min(100%, 480px);
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+/*
+ * Pane background mirrors the Pygments code-block background, with the same
+ * light/dark switching furo uses for `.highlight` (pygments_style and
+ * pygments_dark_style backgrounds).
+ */
+.gp-tmux-layout .pane {
+  fill: #f8fafc;
+}
+
+body[data-theme="dark"] .gp-tmux-layout .pane {
+  fill: #272822;
+}
+
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) .gp-tmux-layout .pane {
+    fill: #272822;
+  }
+}
+
+/* Single-stroke window border and pane dividers. */
+.gp-tmux-layout .window {
+  fill: none;
+  stroke: var(--color-background-border, #cccccc);
+  stroke-width: 1;
+}
+
+.gp-tmux-layout .divider {
+  stroke: var(--color-background-border, #cccccc);
+  stroke-width: 1;
+}
+
+.gp-tmux-layout text {
+  font-family: var(--font-stack--monospace, "SFMono-Regular", Menlo, monospace);
+  font-size: var(--code-font-size, 0.8125rem);
+  /* Match the site's code blocks (pre): even monospace advance, no kerning. */
+  font-kerning: none;
+  text-rendering: optimizeSpeed;
+  letter-spacing: normal;
+  /* Colour comes from furo's .highlight / .highlight .nb / .gp rules. */
+  fill: currentColor;
+}
+
+.gp-tmux-layout-wrapper > figcaption {
+  text-align: center;
+  font-size: 0.9em;
+  margin-top: 0.5rem;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,8 +34,12 @@ conf = merge_sphinx_config(
     extra_extensions=[
         "sphinx_autodoc_api_style",
         "aafig",
+        "mermaid_inline",
         "sphinx_autodoc_argparse.exemplar",
     ],
+    # Route a plain ```mermaid fence to the mermaid_inline directive (the colon
+    # and brace forms route there already via colon_fence).
+    myst_fence_as_directive=["mermaid"],
     intersphinx_mapping={
         "python": ("https://docs.python.org/", None),
         "libtmux": ("https://libtmux.git-pull.com/", None),
@@ -48,8 +52,15 @@ conf = merge_sphinx_config(
     aafig_format={"latex": "pdf", "html": "gif"},
     aafig_default_options={"scale": 0.75, "aspect": 0.5, "proportional": True},
     rediraffe_redirects="redirects.txt",
-    # AGENTS.md (+ its CLAUDE.md symlink) is agent guidance, not a site
-    # page; keep Sphinx from treating it as an orphan document.
-    exclude_patterns=["_build", "AGENTS.md", "CLAUDE.md"],
+    # Keep Sphinx out of non-document trees under docs/: the mermaid toolchain
+    # (node_modules) and its render cache, plus agent guidance (AGENTS.md and
+    # its CLAUDE.md symlink) which would otherwise be orphan documents.
+    exclude_patterns=[
+        "_build",
+        "node_modules",
+        "_mermaid_cache",
+        "AGENTS.md",
+        "CLAUDE.md",
+    ],
 )
 globals().update(conf)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ conf = merge_sphinx_config(
         "sphinx_autodoc_api_style",
         "aafig",
         "mermaid_inline",
+        "tmux_layout",
         "sphinx_autodoc_argparse.exemplar",
     ],
     # Route a plain ```mermaid fence to the mermaid_inline directive (the colon

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,8 @@ conf = merge_sphinx_config(
     aafig_format={"latex": "pdf", "html": "gif"},
     aafig_default_options={"scale": 0.75, "aspect": 0.5, "proportional": True},
     rediraffe_redirects="redirects.txt",
-    # AGENTS.md is agent guidance, not a site page; keep Sphinx from
-    # treating it as an orphan document.
-    exclude_patterns=["_build", "AGENTS.md"],
+    # AGENTS.md (+ its CLAUDE.md symlink) is agent guidance, not a site
+    # page; keep Sphinx from treating it as an orphan document.
+    exclude_patterns=["_build", "AGENTS.md", "CLAUDE.md"],
 )
 globals().update(conf)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,5 +48,8 @@ conf = merge_sphinx_config(
     aafig_format={"latex": "pdf", "html": "gif"},
     aafig_default_options={"scale": 0.75, "aspect": 0.5, "proportional": True},
     rediraffe_redirects="redirects.txt",
+    # AGENTS.md is agent guidance, not a site page; keep Sphinx from
+    # treating it as an orphan document.
+    exclude_patterns=["_build", "AGENTS.md"],
 )
 globals().update(conf)

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -7,17 +7,17 @@
 tmuxp has a short-hand syntax for those who wish to keep their workspace
 punctual.
 
-::::{sidebar} short hand
+:::{tmux-layout}
+:size: 36x12
+:layout: even-vertical
 
-```mermaid
-block-beta
-  columns 1
-  p1["'did you know'<br/>'you can inline'"]
-  p2["'single commands'"]
-  p3["'for panes'"]
-```
-
-::::
+echo 'did you know'
+echo 'you can inline'
+---
+echo 'single commands'
+---
+echo 'for panes'
+:::
 
 ````{tab} YAML
 
@@ -65,16 +65,14 @@ Note `''` counts as an empty carriage return.
 
 ## 2 panes
 
-::::{sidebar} 2 pane
+:::{tmux-layout}
+:size: 30x10
+:layout: even-vertical
 
-```mermaid
-block-beta
-  columns 1
-  a["$ pwd"]
-  b["$ pwd"]
-```
-
-::::
+pwd
+---
+pwd
+:::
 
 ````{tab} YAML
 
@@ -96,16 +94,16 @@ block-beta
 
 ## 3 panes
 
-::::{sidebar} 3 panes
+:::{tmux-layout}
+:size: 30x12
+:layout: main-horizontal
 
-```mermaid
-block-beta
-  columns 2
-  top["$ pwd"]:2
-  bl["$ pwd"] br["$ pwd"]
-```
-
-::::
+pwd
+---
+pwd
+---
+pwd
+:::
 
 ````{tab} YAML
 
@@ -127,16 +125,18 @@ block-beta
 
 ## 4 panes
 
-::::{sidebar} 4 panes
+:::{tmux-layout}
+:size: 30x12
+:layout: tiled
 
-```mermaid
-block-beta
-  columns 2
-  a["$ pwd"] b["$ pwd"]
-  c["$ pwd"] d["$ pwd"]
-```
-
-::::
+pwd
+---
+pwd
+---
+pwd
+---
+pwd
+:::
 
 ````{tab} YAML
 

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -9,20 +9,12 @@ punctual.
 
 ::::{sidebar} short hand
 
-```{eval-rst}
-.. aafig::
-   :textual:
-
-    +-------------------+
-    | 'did you know'    |
-    | 'you can inline'  |
-    +-------------------+
-    | 'single commands' |
-    |                   |
-    +-------------------+
-    | 'for panes'       |
-    |                   |
-    +-------------------+
+```mermaid
+block-beta
+  columns 1
+  p1["'did you know'<br/>'you can inline'"]
+  p2["'single commands'"]
+  p3["'for panes'"]
 ```
 
 ::::
@@ -75,18 +67,11 @@ Note `''` counts as an empty carriage return.
 
 ::::{sidebar} 2 pane
 
-```{eval-rst}
-.. aafig::
-
-    +-----------------+
-    | $ pwd           |
-    |                 |
-    |                 |
-    +-----------------+
-    | $ pwd           |
-    |                 |
-    |                 |
-    +-----------------+
+```mermaid
+block-beta
+  columns 1
+  a["$ pwd"]
+  b["$ pwd"]
 ```
 
 ::::
@@ -113,18 +98,11 @@ Note `''` counts as an empty carriage return.
 
 ::::{sidebar} 3 panes
 
-```{eval-rst}
-.. aafig::
-
-    +-----------------+
-    | $ pwd           |
-    |                 |
-    |                 |
-    +--------+--------+
-    | $ pwd  | $ pwd  |
-    |        |        |
-    |        |        |
-    +--------+--------+
+```mermaid
+block-beta
+  columns 2
+  top["$ pwd"]:2
+  bl["$ pwd"] br["$ pwd"]
 ```
 
 ::::
@@ -151,18 +129,11 @@ Note `''` counts as an empty carriage return.
 
 ::::{sidebar} 4 panes
 
-```{eval-rst}
-.. aafig::
-
-    +--------+--------+
-    | $ pwd  | $ pwd  |
-    |        |        |
-    |        |        |
-    +--------+--------+
-    | $ pwd  | $ pwd  |
-    |        |        |
-    |        |        |
-    +--------+--------+
+```mermaid
+block-beta
+  columns 2
+  a["$ pwd"] b["$ pwd"]
+  c["$ pwd"] d["$ pwd"]
 ```
 
 ::::

--- a/docs/configuration/workspace-builders.md
+++ b/docs/configuration/workspace-builders.md
@@ -35,8 +35,9 @@ boundary that comes with running builder code.
 
 ## `workspace_builder`
 
-Selects the builder. The default, `classic`, is tmuxp's built-in builder. A value
-is resolved in this order:
+This is where you name the builder. Leave it out — or set `classic` — and you get
+tmuxp's built-in builder, with nothing imported. When you name something else, tmuxp
+works out what you mean from the shape of the value, in this order:
 
 1. absent or empty → the built-in classic builder (nothing is imported);
 2. contains `:` → a `module:attr` object reference;
@@ -60,11 +61,12 @@ See {ref}`custom-workspace-builders` for selecting and packaging builders, and
 
 ## `workspace_builder_paths`
 
-Directories to import a builder from when it lives outside tmuxp's environment —
-for example, a script in your config directory. Accepts a single string or a list
-of strings. tmuxp expands `~` and environment variables, resolves relative entries
-against the workspace file's directory, and requires each entry to be an existing
-directory; the paths are added to `sys.path` only for the import and build.
+When your builder lives outside tmuxp's environment — say, a script sitting in your
+config directory — this tells tmuxp where to find it. Give it a single directory or a
+list of them. tmuxp expands `~` and environment variables, reads relative entries
+against the workspace file's own directory, and expects each one to be a directory
+that already exists. The paths join `sys.path` only for the import and build, not for
+the rest of your session.
 
 ```yaml
 workspace_builder: my_local_builder:CustomBuilder
@@ -81,10 +83,10 @@ workspace files you trust. See the security note in {ref}`custom-workspace-build
 
 ## `workspace_builder_options`
 
-A catalog of builder-behavior settings, independent of which builder you use.
-Today it holds a single key, `pane_readiness`, which controls whether tmuxp waits
-for a pane's shell prompt before sending its layout and commands — a guard against
-a zsh prompt-redraw artifact:
+This holds builder-behavior settings, whichever builder you use. For now there's just
+one, `pane_readiness`, which decides whether tmuxp waits for a pane's shell prompt
+before it sends that pane's layout and commands — a guard against a zsh prompt-redraw
+artifact:
 
 ```yaml
 workspace_builder_options:
@@ -105,7 +107,7 @@ workspace_builder_options:
 invalid pane_readiness value: 'sometimes'; expected one of: auto, always/true/on/yes/1, never/false/off/no/0
 ```
 
-Panes that run a custom `shell` or `window_shell` never wait, regardless of policy.
+A pane that runs a custom `shell` or `window_shell` never waits, whatever you set here.
 See {class}`~tmuxp.workspace.options.PaneReadiness` and
 {class}`~tmuxp.workspace.options.WorkspaceBuilderOptions` for the parsing rules.
 

--- a/docs/configuration/workspace-builders.md
+++ b/docs/configuration/workspace-builders.md
@@ -5,20 +5,30 @@
 ```{versionadded} 1.72.0
 ```
 
-Most workspaces never need these keys. By default tmuxp builds your session with
-its built-in *classic* builder and waits for a pane's shell prompt only when that
-shell is zsh — existing workspace files keep working unchanged. Set the keys below
-to swap in a different builder or to tune the prompt wait. **Omit a key (or remove
-it) to restore the default.**
+A *workspace builder* is the part of tmuxp that turns a workspace configuration into a
+live tmux session — it creates the session, lays out its windows and panes, and runs
+their commands. You usually never have to think about it: tmuxp ships with a built-in
+*classic* builder, and your YAML or JSON workspace files load through it out of the
+box, just as they always have. **Everything on this page is optional; leave a setting
+out to fall back to the default.**
+
+Workspaces with special needs can reach for a builder's options to fine-tune how a
+session loads. The classic builder, for instance, can wait for a pane's shell prompt
+before sending its layout and commands — by default only when that shell is zsh (the
+`pane_readiness` option). Waiting makes a session a little slower to load, but
+guarantees the workspace is fully prepped before you attach.
+
+You can also send a workspace through a different or custom builder instead of the
+classic one, and tune its options the same way. For the braver cases, you can subclass
+the classic builder or write your own in Python on top of libtmux — see
+{ref}`custom-workspace-builders` for writing, packaging, testing, and the trust
+boundary that comes with running builder code.
 
 | Key | Type | Default | Purpose |
 | --- | --- | --- | --- |
 | `workspace_builder` | string | `classic` | Which builder turns the workspace into a session. |
 | `workspace_builder_paths` | string or list of strings | _(none)_ | Trusted directories to import a builder from. |
-| `workspace_builder_options` | mapping | _(all defaults)_ | Builder-behavior knobs, such as `pane_readiness`. |
-
-For the narrative — writing a builder, packaging one, the trust boundary, and
-testing — see {ref}`custom-workspace-builders`.
+| `workspace_builder_options` | mapping | _(all defaults)_ | Builder-behavior settings, such as `pane_readiness`. |
 
 (workspace-builder-key)=
 

--- a/docs/configuration/workspace-builders.md
+++ b/docs/configuration/workspace-builders.md
@@ -20,7 +20,8 @@ guarantees the workspace is fully prepped before you attach.
 
 You can also send a workspace through a different or custom builder instead of the
 classic one, and tune its options the same way. For the braver cases, you can subclass
-the classic builder or write your own in Python on top of libtmux — see
+the classic builder or write your own in Python on top of
+[libtmux](https://libtmux.git-pull.com/) — see
 {ref}`custom-workspace-builders` for writing, packaging, testing, and the trust
 boundary that comes with running builder code.
 

--- a/docs/configuration/workspace-builders.md
+++ b/docs/configuration/workspace-builders.md
@@ -15,7 +15,7 @@ out to fall back to the default.**
 :::{mermaid}
 :caption: How a workspace file becomes a live tmux session.
 
-flowchart LR
+flowchart TD
     load["tmuxp load &lt;workspace-file&gt;"] -->|reads workspace config| builder["Workspace Builder"]
     builder -->|"creates session, windows, panes"| attach["Attach tmux session"]
 :::

--- a/docs/configuration/workspace-builders.md
+++ b/docs/configuration/workspace-builders.md
@@ -15,6 +15,11 @@ out to fall back to the default.**
 :::{mermaid}
 :caption: How a workspace file becomes a live tmux session.
 
+---
+config:
+  flowchart:
+    wrappingWidth: 500
+---
 flowchart TD
     load["tmuxp load &lt;workspace-file&gt;"] -->|reads workspace config| builder["Workspace Builder"]
     builder -->|"creates session, windows, panes"| attach["Attach tmux session"]

--- a/docs/configuration/workspace-builders.md
+++ b/docs/configuration/workspace-builders.md
@@ -21,7 +21,7 @@ config:
     wrappingWidth: 500
 ---
 flowchart TD
-    load["tmuxp load &lt;workspace-file&gt;"] -->|reads workspace config| builder["Workspace Builder"]
+    load["tmuxp load &lt;workspace-file&gt;"]:::cmd -->|reads workspace config| builder["Workspace Builder"]
     builder -->|"creates session, windows, panes"| attach["Attach tmux session"]
 :::
 

--- a/docs/configuration/workspace-builders.md
+++ b/docs/configuration/workspace-builders.md
@@ -12,6 +12,14 @@ their commands. You usually never have to think about it: tmuxp ships with a bui
 box, just as they always have. **Everything on this page is optional; leave a setting
 out to fall back to the default.**
 
+:::{mermaid}
+:caption: How a workspace file becomes a live tmux session.
+
+flowchart LR
+    load["tmuxp load &lt;workspace-file&gt;"] -->|reads workspace config| builder["Workspace Builder"]
+    builder -->|"creates session, windows, panes"| attach["Attach tmux session"]
+:::
+
 Workspaces with special needs can reach for a builder's options to fine-tune how a
 session loads. The classic builder, for instance, can wait for a pane's shell prompt
 before sending its layout and commands — by default only when that shell is zsh (the

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "tmuxp-docs",
+  "private": true,
+  "description": "Build-time tooling for the tmuxp docs (mermaid diagram rendering).",
+  "devDependencies": {
+    "@mermaid-js/mermaid-cli": "11.15.0"
+  }
+}

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -1,0 +1,2281 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@mermaid-js/mermaid-cli':
+        specifier: 11.15.0
+        version: 11.15.0(puppeteer@24.43.1)(tailwindcss@4.3.1)
+
+packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.26.28':
+    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fortawesome/fontawesome-free@7.3.0':
+    resolution: {integrity: sha512-Yw4Qa43P6e4Xwh0TwEUkHQNRJInWaqIBo73VJmns3j2AIlZPAvUcR4yGIxCPqPRCgyJ5KIVIalF/I1GxhZ/Kgw==}
+    engines: {node: '>=6'}
+
+  '@headlessui/react@2.2.10':
+    resolution: {integrity: sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  '@headlessui/tailwindcss@0.2.2':
+    resolution: {integrity: sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      tailwindcss: ^3.0 || ^4.0
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.9':
+    resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
+
+  '@mermaid-js/layout-elk@0.2.2':
+    resolution: {integrity: sha512-vnH3gtqfhyBiRVKNpT8iDENTw18q/OF0GF/SfYfHN43KZpu+6eZDEOMHTfNYAkpmUWJNgtRQFIS6BTc7vH/DYQ==}
+    peerDependencies:
+      mermaid: ^11.0.2
+
+  '@mermaid-js/layout-tidy-tree@0.2.2':
+    resolution: {integrity: sha512-8RmjDXjKJBxqTS1mICStm8zWRM45fSzs0SOrkp28+KsOGS2YEMFMVTwwRU8CsC6M1L+pDYZVjf1m9AC1c9Wndg==}
+    peerDependencies:
+      mermaid: ^11.0.2
+
+  '@mermaid-js/mermaid-cli@11.15.0':
+    resolution: {integrity: sha512-rmz9ELKtmKQvRcYJGI2e509FK9yCBvmEVfHeRSYkleGqo6qqh8LFooxRPCqq04uVx3JHMp9g/vmM85gi/QFFlQ==}
+    engines: {node: ^18.19 || >=20.0}
+    hasBin: true
+    peerDependencies:
+      puppeteer: ^23 || ^24
+
+  '@mermaid-js/mermaid-zenuml@0.2.3':
+    resolution: {integrity: sha512-RGBtgL6fc+5Y2Jm9odOH9HRJ80BP4l6atBYnAK5bBzEowF0PU3UtvZRRcbFxImPGPuLIzqZq31ur8lVO0AoF3Q==}
+    peerDependencies:
+      mermaid: ^10 || ^11
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
+
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@react-aria/focus@3.22.1':
+    resolution: {integrity: sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/interactions@3.28.1':
+    resolution: {integrity: sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/shared@3.36.0':
+    resolution: {integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@tanstack/react-virtual@3.14.4':
+    resolution: {integrity: sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.2':
+    resolution: {integrity: sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA==}
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/node@26.0.1':
+    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@zenuml/core@3.50.1':
+    resolution: {integrity: sha512-Q18BXvIfhRuGw0JfO4e+pltG04Phhv2E7n35EWTNSZKKH/HEkyE4Sh7KERb9dqaOfjOdRdKvLG0YekjK3fcDXw==}
+    engines: {node: '>=20'}
+    hasBin: true
+    peerDependencies:
+      playwright-core: 1.57.0
+    peerDependenciesMeta:
+      playwright-core:
+        optional: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  antlr4@4.11.0:
+    resolution: {integrity: sha512-GUGlpE2JUjAN+G8G5vY+nOoeyNhHsXoIJwP1XF1oRw89vifA1K46T6SEkwLwr7drihN7I/lf0DIjKc4OZvBX8w==}
+    engines: {node: '>=14'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.2:
+    resolution: {integrity: sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.2:
+    resolution: {integrity: sha512-h530JsrkYi8518ZfR57GHaLoI5YzXkGGEV0Y+mf4KYPBn4OnNajiznwkDq7FgE+Vnmyss9Utnzi44y7sowiAXA==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.1:
+    resolution: {integrity: sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.5:
+    resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
+    engines: {node: '>=12.20'}
+
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
+  devtools-protocol@0.0.1608973:
+    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+
+  elkjs@0.9.3:
+    resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
+
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  jotai@2.20.1:
+    resolution: {integrity: sha512-dnuKfU/GLi8B28RRMjQ3AfoN7kfzP8o41+AX2FmITZqEMY8PHnjABq+VkEooomLwYaGjda+pgy0yFSjaHX/ZPg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
+
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  p-limit@6.2.0:
+    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
+    engines: {node: '>=18'}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  puppeteer-core@24.43.1:
+    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
+    engines: {node: '>=18'}
+
+  puppeteer@24.43.1:
+    resolution: {integrity: sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  react-aria@3.50.0:
+    resolution: {integrity: sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-stately@3.48.0:
+    resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwindcss@4.3.1:
+    resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
+
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.2.4
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@floating-ui/react@0.26.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tabbable: 6.5.0
+
+  '@floating-ui/react@0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tabbable: 6.5.0
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@fortawesome/fontawesome-free@7.3.0': {}
+
+  '@headlessui/react@2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react': 0.26.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-aria/focus': 3.22.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-aria/interactions': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-virtual': 3.14.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.3.1)':
+    dependencies:
+      tailwindcss: 4.3.1
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
+  '@internationalized/date@3.12.2':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/string@3.2.9':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@mermaid-js/layout-elk@0.2.2(mermaid@11.16.0)':
+    dependencies:
+      d3: 7.9.0
+      elkjs: 0.9.3
+      mermaid: 11.16.0
+
+  '@mermaid-js/layout-tidy-tree@0.2.2(mermaid@11.16.0)':
+    dependencies:
+      d3: 7.9.0
+      mermaid: 11.16.0
+    optional: true
+
+  '@mermaid-js/mermaid-cli@11.15.0(puppeteer@24.43.1)(tailwindcss@4.3.1)':
+    dependencies:
+      '@fortawesome/fontawesome-free': 7.3.0
+      '@mermaid-js/layout-elk': 0.2.2(mermaid@11.16.0)
+      '@mermaid-js/mermaid-zenuml': 0.2.3(mermaid@11.16.0)(tailwindcss@4.3.1)
+      chalk: 5.6.2
+      commander: 13.1.0
+      import-meta-resolve: 4.2.0
+      katex: 0.16.47
+      mermaid: 11.16.0
+      p-limit: 6.2.0
+      puppeteer: 24.43.1
+    optionalDependencies:
+      '@mermaid-js/layout-tidy-tree': 0.2.2(mermaid@11.16.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - playwright-core
+      - tailwindcss
+
+  '@mermaid-js/mermaid-zenuml@0.2.3(mermaid@11.16.0)(tailwindcss@4.3.1)':
+    dependencies:
+      '@zenuml/core': 3.50.1(tailwindcss@4.3.1)
+      mermaid: 11.16.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - playwright-core
+      - tailwindcss
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
+
+  '@puppeteer/browsers@2.13.2':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.8.5
+      tar-fs: 3.1.3
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  '@react-aria/focus@3.22.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@swc/helpers': 0.5.23
+      react: 19.2.7
+      react-aria: 3.50.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@react-aria/interactions@3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@react-types/shared': 3.36.0(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      react: 19.2.7
+      react-aria: 3.50.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@react-types/shared@3.36.0(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tanstack/react-virtual@3.14.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/virtual-core@3.17.2': {}
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/node@26.0.1':
+    dependencies:
+      undici-types: 8.3.0
+    optional: true
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 26.0.1
+    optional: true
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@zenuml/core@3.50.1(tailwindcss@4.3.1)':
+    dependencies:
+      '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@headlessui/react': 2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.1)
+      antlr4: 4.11.0
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      color-string: 2.1.4
+      dompurify: 3.4.11
+      highlight.js: 11.11.1
+      html-to-image: 1.11.13
+      jotai: 2.20.1(react@19.2.7)
+      marked: 4.3.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tailwind-merge: 3.6.0
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - tailwindcss
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  antlr4@4.11.0: {}
+
+  argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
+  b4a@1.8.1: {}
+
+  bare-events@2.9.1: {}
+
+  bare-fs@4.7.2:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.0.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.5
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.2: {}
+
+  bare-path@3.0.1:
+    dependencies:
+      bare-os: 3.9.2
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.5:
+    dependencies:
+      bare-path: 3.0.1
+
+  basic-ftp@5.3.1: {}
+
+  buffer-crc32@0.2.13: {}
+
+  callsites@3.1.0: {}
+
+  chalk@5.6.2: {}
+
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
+    dependencies:
+      devtools-protocol: 0.0.1608973
+      mitt: 3.0.1
+      zod: 3.25.76
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  color-name@2.1.0: {}
+
+  color-string@2.1.4:
+    dependencies:
+      color-name: 2.1.0
+
+  commander@13.1.0: {}
+
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
+  cosmiconfig@9.0.2:
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.3.0
+      parse-json: 5.2.0
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  data-uri-to-buffer@6.0.2: {}
+
+  dayjs@1.11.21: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
+  devtools-protocol@0.0.1608973: {}
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  elkjs@0.9.3: {}
+
+  emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es-toolkit@1.49.0: {}
+
+  escalade@3.2.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
+  esprima@4.0.1: {}
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-fifo@1.3.2: {}
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
+  get-caller-file@2.0.5: {}
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hachure-fill@0.5.2: {}
+
+  highlight.js@11.11.1: {}
+
+  html-to-image@1.11.13: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
+
+  ip-address@10.2.0: {}
+
+  is-arrayish@0.2.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  jotai@2.20.1(react@19.2.7):
+    optionalDependencies:
+      react: 19.2.7
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
+
+  lines-and-columns@1.2.4: {}
+
+  lodash-es@4.18.1: {}
+
+  lru-cache@7.18.3: {}
+
+  marked@16.4.2: {}
+
+  marked@4.3.0: {}
+
+  mermaid@11.16.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.11
+      es-toolkit: 1.49.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
+
+  mitt@3.0.1: {}
+
+  ms@2.1.3: {}
+
+  netmask@2.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
+  package-manager-detector@1.6.0: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  path-data-parser@0.1.0: {}
+
+  pend@1.2.0: {}
+
+  picocolors@1.1.1: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+
+  progress@2.0.3: {}
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  puppeteer-core@24.43.1:
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1608973
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  puppeteer@24.43.1:
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      cosmiconfig: 9.0.2
+      devtools-protocol: 0.0.1608973
+      puppeteer-core: 24.43.1
+      typed-query-selector: 2.12.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  react-aria@3.50.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.36.0(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-stately: 3.48.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-stately@3.48.0(react@19.2.7):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.36.0(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  react@19.2.7: {}
+
+  require-directory@2.1.1: {}
+
+  resolve-from@4.0.0: {}
+
+  robust-predicates@3.0.3: {}
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rw@1.3.3: {}
+
+  safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
+
+  semver@7.8.5: {}
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+
+  source-map@0.6.1:
+    optional: true
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  stylis@4.4.0: {}
+
+  tabbable@6.5.0: {}
+
+  tailwind-merge@3.6.0: {}
+
+  tailwindcss@4.3.1: {}
+
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.0
+    optionalDependencies:
+      bare-fs: 4.7.2
+      bare-path: 3.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.2
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  tinyexec@1.2.4: {}
+
+  ts-dedent@2.3.0: {}
+
+  tslib@2.8.1: {}
+
+  typed-query-selector@2.12.2: {}
+
+  undici-types@8.3.0:
+    optional: true
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  uuid@14.0.1: {}
+
+  webdriver-bidi-protocol@0.4.1: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+
+  yocto-queue@1.2.2: {}
+
+  zod@3.25.76: {}

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+# Allow @mermaid-js/mermaid-cli's puppeteer dependency to run its install
+# script, which fetches the headless Chrome used to render diagrams.
+allowBuilds:
+  puppeteer: true

--- a/tests/test_docs_mermaid.py
+++ b/tests/test_docs_mermaid.py
@@ -272,7 +272,7 @@ def test_render_cache_is_idempotent(
     """``_render_cached`` invokes mmdc once, then serves from the disk cache."""
     calls = {"n": 0}
 
-    def fake_render(app: object, source: str, theme: str) -> str:
+    def fake_render(app: object, source: str, config_json: str) -> str:
         calls["n"] += 1
         return _FAKE_MMDC_SVG
 
@@ -283,8 +283,12 @@ def test_render_cache_is_idempotent(
     )
     app = types.SimpleNamespace(confdir=str(tmp_path), config=config)
 
-    first = mi._render_cached(t.cast("t.Any", app), "flowchart LR a-->b", "default")
-    second = mi._render_cached(t.cast("t.Any", app), "flowchart LR a-->b", "default")
+    first = mi._render_cached(
+        t.cast("t.Any", app), "flowchart LR a-->b", mi._THEME_LIGHT
+    )
+    second = mi._render_cached(
+        t.cast("t.Any", app), "flowchart LR a-->b", mi._THEME_LIGHT
+    )
 
     assert first == second == _FAKE_MMDC_SVG
     assert calls["n"] == 1

--- a/tests/test_docs_mermaid.py
+++ b/tests/test_docs_mermaid.py
@@ -81,6 +81,16 @@ _NORMALIZE_CASES: list[NormalizeCase] = [
         expect_contains=('width="1141.25"', 'height="94"'),
         expect_absent=("max-width",),
     ),
+    NormalizeCase(
+        test_id="block-negative-viewbox-origin",
+        raw_svg=(
+            '<svg id="my-svg" width="100%" viewBox="-5 -97 148 194">'
+            '<marker viewBox="0 0 10 10"/></svg>'
+        ),
+        svg_id="mermaid-blk-light",
+        expect_contains=('width="148"', 'height="194"'),
+        expect_absent=('width="100%"', 'width="10"'),
+    ),
 ]
 
 

--- a/tests/test_docs_mermaid.py
+++ b/tests/test_docs_mermaid.py
@@ -1,0 +1,295 @@
+"""Tests for the build-time mermaid inline-SVG extension (``docs/_ext``)."""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import types
+import typing as t
+from pathlib import Path
+
+import pytest
+from docutils import nodes
+
+# The extension lives under docs/_ext (not an installed package), so load it
+# from its file path rather than importing it by name.
+_EXT_PATH = (
+    Path(__file__).resolve().parent.parent / "docs" / "_ext" / "mermaid_inline.py"
+)
+_spec = importlib.util.spec_from_file_location("mermaid_inline", _EXT_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+mi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mi)
+
+# A stand-in for mmdc's real output: fixed ``my-svg`` id, responsive width with
+# no height, an inline ``max-width``, an id-scoped style, and a marker ref.
+_FAKE_MMDC_SVG = (
+    '<svg id="my-svg" width="100%" '
+    'style="max-width: 200px; background-color: transparent;" '
+    'viewBox="0 0 200 80" role="graphics-document document">'
+    "<style>#my-svg{fill:#333;}</style>"
+    '<g class="node">a</g>'
+    '<path marker-end="url(#my-svg_flowchart-pointEnd)"></path>'
+    "</svg>"
+)
+
+
+class NormalizeCase(t.NamedTuple):
+    """A ``_normalize_svg`` scenario and its expected substrings."""
+
+    test_id: str
+    raw_svg: str
+    svg_id: str
+    expect_contains: tuple[str, ...]
+    expect_absent: tuple[str, ...]
+
+
+_NORMALIZE_CASES: list[NormalizeCase] = [
+    NormalizeCase(
+        test_id="width-and-height-from-viewbox",
+        raw_svg=(
+            '<svg id="my-svg" width="100%" style="max-width: 200px;" '
+            'viewBox="0 0 200 80"><style>#my-svg{fill:#333;}</style></svg>'
+        ),
+        svg_id="mermaid-deadbeef-light",
+        expect_contains=(
+            'width="200"',
+            'height="80"',
+            'id="mermaid-deadbeef-light"',
+            "#mermaid-deadbeef-light{",
+        ),
+        expect_absent=("my-svg", "max-width", 'width="100%"'),
+    ),
+    NormalizeCase(
+        test_id="marker-references-rewritten",
+        raw_svg=(
+            '<svg id="my-svg" width="100%" viewBox="0 0 10 10">'
+            '<g marker-end="url(#my-svg_end)"/></svg>'
+        ),
+        svg_id="mermaid-abc-dark",
+        expect_contains=("url(#mermaid-abc-dark_end)", 'width="10"', 'height="10"'),
+        expect_absent=("my-svg",),
+    ),
+    NormalizeCase(
+        test_id="decimal-viewbox-dimensions",
+        raw_svg=(
+            '<svg id="my-svg" width="100%" style="max-width: 1141.25px;" '
+            'viewBox="0 0 1141.25 94"></svg>'
+        ),
+        svg_id="mermaid-x-light",
+        expect_contains=('width="1141.25"', 'height="94"'),
+        expect_absent=("max-width",),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _NORMALIZE_CASES,
+    ids=[c.test_id for c in _NORMALIZE_CASES],
+)
+def test_normalize_svg(case: NormalizeCase) -> None:
+    """``_normalize_svg`` rewrites the id, sets size, and drops ``max-width``."""
+    out = mi._normalize_svg(case.raw_svg, svg_id=case.svg_id)
+    for needle in case.expect_contains:
+        assert needle in out, f"{case.test_id}: expected {needle!r}"
+    for needle in case.expect_absent:
+        assert needle not in out, f"{case.test_id}: unexpected {needle!r}"
+
+
+class DigestCase(t.NamedTuple):
+    """Two ``_diagram_digest`` inputs and whether their hashes should match."""
+
+    test_id: str
+    a_source: str
+    a_theme: str
+    b_source: str
+    b_theme: str
+    expect_equal: bool
+
+
+_DIGEST_CASES: list[DigestCase] = [
+    DigestCase(
+        "identical-inputs-match",
+        "flowchart LR a-->b",
+        "default",
+        "flowchart LR a-->b",
+        "default",
+        True,
+    ),
+    DigestCase(
+        "theme-differs",
+        "flowchart LR a-->b",
+        "default",
+        "flowchart LR a-->b",
+        "dark",
+        False,
+    ),
+    DigestCase(
+        "source-differs",
+        "flowchart LR a-->b",
+        "default",
+        "flowchart LR a-->c",
+        "default",
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _DIGEST_CASES,
+    ids=[c.test_id for c in _DIGEST_CASES],
+)
+def test_diagram_digest(case: DigestCase) -> None:
+    """``_diagram_digest`` is stable per input and varies by theme and source."""
+    a = mi._diagram_digest(case.a_source, case.a_theme)
+    b = mi._diagram_digest(case.b_source, case.b_theme)
+    assert (a == b) is case.expect_equal
+    assert len(a) == 40
+
+
+def test_svg_element_id_is_themed_and_unique() -> None:
+    """``_svg_element_id`` yields distinct, theme-suffixed ids per variant."""
+    digest = mi._diagram_digest("flowchart LR a-->b", "")
+    light = mi._svg_element_id(digest, "light")
+    dark = mi._svg_element_id(digest, "dark")
+    assert light != dark
+    assert light.startswith("mermaid-")
+    assert light.endswith("-light")
+
+
+def _make_translator(tmp_path: Path) -> types.SimpleNamespace:
+    """Return a minimal stand-in for the HTML translator the visitor needs."""
+    config = types.SimpleNamespace(
+        mermaid_inline_cmd="",
+        mermaid_inline_puppeteer_config="",
+    )
+    app = types.SimpleNamespace(confdir=str(tmp_path), config=config)
+    builder = types.SimpleNamespace(app=app)
+    return types.SimpleNamespace(builder=builder, body=[])
+
+
+def test_visitor_emits_dual_themed_svg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The visitor inlines one light and one dark SVG with shared geometry."""
+    seen: list[str] = []
+
+    def fake_render_cached(app: object, source: str, theme: str) -> str:
+        seen.append(theme)
+        return _FAKE_MMDC_SVG
+
+    monkeypatch.setattr(mi, "_render_cached", fake_render_cached)
+    translator = _make_translator(tmp_path)
+    node = mi.mermaid_inline()
+    node["mermaid_source"] = "flowchart LR a-->b"
+    node["caption"] = "How it flows"
+    node["alt"] = ""
+
+    with pytest.raises(nodes.SkipNode):
+        mi.html_visit_mermaid_inline(t.cast("t.Any", translator), node)
+
+    html = "".join(translator.body)
+    assert seen == [mi._THEME_LIGHT, mi._THEME_DARK]
+    assert html.count("gp-diagram--light") == 1
+    assert html.count("gp-diagram--dark") == 1
+    assert "<figcaption>How it flows</figcaption>" in html
+    assert "my-svg" not in html
+    # Both variants normalized to identical geometry -> shift-free toggle.
+    assert html.count('viewBox="0 0 200 80"') == 2
+
+
+def test_visitor_falls_back_when_renderer_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A missing renderer degrades to a text fallback and warns once."""
+    monkeypatch.setattr(mi, "_render_warned", False)
+
+    def boom(app: object, source: str, theme: str) -> str:
+        msg = "no mmdc"
+        raise mi.MermaidRendererMissing(msg)
+
+    monkeypatch.setattr(mi, "_render_cached", boom)
+    translator = _make_translator(tmp_path)
+    node = mi.mermaid_inline()
+    node["mermaid_source"] = "flowchart LR a-->b"
+    node["caption"] = ""
+    node["alt"] = ""
+
+    with caplog.at_level(logging.WARNING), pytest.raises(nodes.SkipNode):
+        mi.html_visit_mermaid_inline(t.cast("t.Any", translator), node)
+
+    html = "".join(translator.body)
+    assert 'class="gp-diagram-fallback"' in html
+    assert "flowchart LR a--&gt;b" in html
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("mermaid render unavailable" in r.getMessage() for r in warnings)
+
+
+def test_render_cache_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``_render_cached`` invokes mmdc once, then serves from the disk cache."""
+    calls = {"n": 0}
+
+    def fake_render(app: object, source: str, theme: str) -> str:
+        calls["n"] += 1
+        return _FAKE_MMDC_SVG
+
+    monkeypatch.setattr(mi, "_render", fake_render)
+    config = types.SimpleNamespace(
+        mermaid_inline_cmd="",
+        mermaid_inline_puppeteer_config="",
+    )
+    app = types.SimpleNamespace(confdir=str(tmp_path), config=config)
+
+    first = mi._render_cached(t.cast("t.Any", app), "flowchart LR a-->b", "default")
+    second = mi._render_cached(t.cast("t.Any", app), "flowchart LR a-->b", "default")
+
+    assert first == second == _FAKE_MMDC_SVG
+    assert calls["n"] == 1
+    assert list((tmp_path / "_mermaid_cache").glob("*.svg"))
+
+
+def test_setup_registers_components() -> None:
+    """``setup`` registers the node, directive, config values, css, and is safe."""
+    recorded: dict[str, list[t.Any]] = {
+        "nodes": [],
+        "directives": [],
+        "config": [],
+        "css": [],
+    }
+
+    def add_node(node: object, **kwargs: object) -> None:
+        recorded["nodes"].append(node)
+
+    def add_directive(name: str, cls: object) -> None:
+        recorded["directives"].append((name, cls))
+
+    def add_config_value(name: str, default: object, rebuild: object) -> None:
+        recorded["config"].append(name)
+
+    def add_css_file(name: str, **kwargs: object) -> None:
+        recorded["css"].append(name)
+
+    app = types.SimpleNamespace(
+        add_node=add_node,
+        add_directive=add_directive,
+        add_config_value=add_config_value,
+        add_css_file=add_css_file,
+    )
+    meta = mi.setup(t.cast("t.Any", app))
+
+    assert meta["parallel_read_safe"] is True
+    assert meta["parallel_write_safe"] is True
+    assert mi.mermaid_inline in recorded["nodes"]
+    assert ("mermaid", mi.MermaidDirective) in recorded["directives"]
+    assert "mermaid_inline_cmd" in recorded["config"]
+    assert "mermaid_inline_puppeteer_config" in recorded["config"]
+    assert "css/gp-diagram.css" in recorded["css"]

--- a/tests/test_docs_mermaid.py
+++ b/tests/test_docs_mermaid.py
@@ -160,6 +160,40 @@ def test_svg_element_id_is_themed_and_unique() -> None:
     assert light.endswith("-light")
 
 
+class PaletteCase(t.NamedTuple):
+    """A theme name whose furo palette must define the flowchart variables."""
+
+    test_id: str
+    theme: str
+
+
+_PALETTE_CASES: list[PaletteCase] = [
+    PaletteCase(test_id=f"{theme}-palette", theme=theme)
+    for theme in (mi._THEME_LIGHT, mi._THEME_DARK)
+]
+
+_REQUIRED_PALETTE_KEYS = (
+    "primaryColor",
+    "primaryBorderColor",
+    "primaryTextColor",
+    "lineColor",
+    "textColor",
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    _PALETTE_CASES,
+    ids=[c.test_id for c in _PALETTE_CASES],
+)
+def test_palette_defines_flowchart_colors(case: PaletteCase) -> None:
+    """Each theme palette defines the mermaid colour variables as hex values."""
+    palette = mi._PALETTES[case.theme]
+    for key in _REQUIRED_PALETTE_KEYS:
+        assert key in palette, f"{case.test_id}: missing {key}"
+        assert palette[key].startswith("#"), f"{case.test_id}: {key} not hex"
+
+
 def _make_translator(tmp_path: Path) -> types.SimpleNamespace:
     """Return a minimal stand-in for the HTML translator the visitor needs."""
     config = types.SimpleNamespace(

--- a/tests/test_docs_tmux_layout.py
+++ b/tests/test_docs_tmux_layout.py
@@ -1,0 +1,202 @@
+"""Tests for the tmux-layout directive (``docs/_ext/tmux_layout.py``)."""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+import typing as t
+from pathlib import Path
+
+import pytest
+
+_EXT_PATH = Path(__file__).resolve().parent.parent / "docs" / "_ext" / "tmux_layout.py"
+_spec = importlib.util.spec_from_file_location("tmux_layout", _EXT_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+tl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tl)
+
+
+class ArrangeCase(t.NamedTuple):
+    """A named layout with a pane count and the geometry it should produce."""
+
+    test_id: str
+    layout: str
+    n: int
+    expect_count: int
+
+
+_ARRANGE_CASES: list[ArrangeCase] = [
+    ArrangeCase("even-vertical-3", "even-vertical", 3, 3),
+    ArrangeCase("even-horizontal-2", "even-horizontal", 2, 2),
+    ArrangeCase("main-vertical-3", "main-vertical", 3, 3),
+    ArrangeCase("main-horizontal-3", "main-horizontal", 3, 3),
+    ArrangeCase("tiled-4", "tiled", 4, 4),
+    ArrangeCase("tiled-3-spans-last-row", "tiled", 3, 3),
+    ArrangeCase("single-pane", "even-vertical", 1, 1),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _ARRANGE_CASES,
+    ids=[c.test_id for c in _ARRANGE_CASES],
+)
+def test_arrange_fills_screen(case: ArrangeCase) -> None:
+    """Each arrangement returns the right panes and tiles the screen exactly."""
+    width, height = 80, 24
+    rects = tl.arrange(case.layout, case.n, width, height)
+    assert len(rects) == case.expect_count
+    # Non-overlapping panes that fill the screen sum to its area.
+    area = sum(r.w * r.h for r in rects)
+    assert area == pytest.approx(width * height)
+    # Every pane stays within the screen.
+    for r in rects:
+        assert r.x >= -1e-6
+        assert r.y >= -1e-6
+        assert r.x + r.w <= width + 1e-6
+        assert r.y + r.h <= height + 1e-6
+
+
+def test_arrange_unknown_layout_raises() -> None:
+    """An unknown layout name is a clear error."""
+    with pytest.raises(tl.TmuxLayoutError, match="unknown layout"):
+        tl.arrange("spiral", 2, 80, 24)
+
+
+class HighlightCase(t.NamedTuple):
+    """A shell command and the Pygments class its first token should carry."""
+
+    test_id: str
+    command: str
+    expect_class: str
+
+
+_HIGHLIGHT_CASES: list[HighlightCase] = [
+    HighlightCase("single-quoted-string", "echo 'hi there'", 'class="s1"'),
+    HighlightCase("comment", "# a note", 'class="c1"'),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _HIGHLIGHT_CASES,
+    ids=[c.test_id for c in _HIGHLIGHT_CASES],
+)
+def test_highlight_emits_pygments_classes(case: HighlightCase) -> None:
+    """``_highlight`` wraps shell tokens in Pygments-classed tspans."""
+    out = tl._highlight(case.command)
+    assert case.expect_class in out
+    assert "<tspan" in out
+
+
+def test_highlight_leaves_command_builtin_default() -> None:
+    """A command builtin (echo/pwd) is left in the default colour, no nb class."""
+    assert 'class="nb"' not in tl._highlight("echo hello")
+    assert 'class="nb"' not in tl._highlight("pwd")
+
+
+def test_highlight_escapes_markup() -> None:
+    """Angle brackets in a command are HTML-escaped, not emitted as tags."""
+    out = tl._highlight("echo <a>")
+    assert "<a>" not in out
+    assert "&lt;a&gt;" in out
+
+
+class SplitCase(t.NamedTuple):
+    """Directive content lines and the per-pane command lists they yield."""
+
+    test_id: str
+    content: list[str]
+    expect: list[list[str]]
+
+
+_SPLIT_CASES: list[SplitCase] = [
+    SplitCase("two-panes", ["echo a", "---", "echo b"], [["echo a"], ["echo b"]]),
+    SplitCase(
+        "multiline-pane",
+        ["echo a", "echo b", "---", "echo c"],
+        [["echo a", "echo b"], ["echo c"]],
+    ),
+    SplitCase(
+        "blank-lines-dropped", ["echo a", "", "---", "echo b"], [["echo a"], ["echo b"]]
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _SPLIT_CASES,
+    ids=[c.test_id for c in _SPLIT_CASES],
+)
+def test_split_panes(case: SplitCase) -> None:
+    """``_split_panes`` splits on ``---`` and keeps each pane's commands."""
+    assert tl._split_panes(case.content) == case.expect
+
+
+class SizeCase(t.NamedTuple):
+    """A ``:size:`` string and the (cols, rows) it parses to."""
+
+    test_id: str
+    size: str
+    expect: tuple[int, int]
+
+
+_SIZE_CASES: list[SizeCase] = [
+    SizeCase("plain", "64x18", (64, 18)),
+    SizeCase("uppercase-x", "80X24", (80, 24)),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _SIZE_CASES,
+    ids=[c.test_id for c in _SIZE_CASES],
+)
+def test_parse_size(case: SizeCase) -> None:
+    """``_parse_size`` reads a ``WxH`` screen size."""
+    assert tl._parse_size(case.size) == case.expect
+
+
+def test_parse_size_invalid_raises() -> None:
+    """A malformed size is a clear error."""
+    with pytest.raises(tl.TmuxLayoutError, match="invalid size"):
+        tl._parse_size("not-a-size")
+
+
+def test_render_layout_structure() -> None:
+    """The rendered SVG has one window, one rect per pane, and highlighting."""
+    svg = tl.render_layout([["echo a"], ["echo b"]], "even-vertical", (40, 12))
+    assert svg.startswith("<svg")
+    assert 'class="gp-tmux-layout"' in svg
+    assert svg.count('class="window"') == 1
+    assert svg.count('class="pane"') == 2
+    assert 'class="gp"' in svg  # the prompt span on each line
+    assert svg.endswith("</svg>")
+
+
+def test_setup_registers_components() -> None:
+    """``setup`` registers the node, directive, css, and is parallel-safe."""
+    recorded: dict[str, list[t.Any]] = {"nodes": [], "directives": [], "css": []}
+
+    def add_node(node: object, **kwargs: object) -> None:
+        recorded["nodes"].append(node)
+
+    def add_directive(name: str, cls: object) -> None:
+        recorded["directives"].append((name, cls))
+
+    def add_css_file(name: str, **kwargs: object) -> None:
+        recorded["css"].append(name)
+
+    app = types.SimpleNamespace(
+        add_node=add_node,
+        add_directive=add_directive,
+        add_css_file=add_css_file,
+    )
+    meta = tl.setup(t.cast("t.Any", app))
+
+    assert meta["parallel_read_safe"] is True
+    assert meta["parallel_write_safe"] is True
+    assert tl.tmux_layout in recorded["nodes"]
+    assert ("tmux-layout", tl.TmuxLayoutDirective) in recorded["directives"]
+    assert "css/gp-tmux-layout.css" in recorded["css"]


### PR DESCRIPTION
## Summary

- **Add** a build-time **mermaid** pipeline: a `mermaid` directive renders fenced diagrams to inline SVG during the Sphinx build (via `mmdc`), so diagrams paint with the page — no client-side mermaid runtime, no layout shift, no staggered pop-in, and they survive gp-sphinx's SPA navigation as live DOM.
- **Add** a `tmux-layout` directive that draws real tmux pane layouts as inline SVG in pure Python — the aafig successor, tmux-aware. Authors declare a screen size and a named layout; panes tile the screen with single dividers, top-left shell commands, pygments-highlighted in the site's code font and colours.
- **Theme-match** both: diagrams adapt to light/dark from furo's own tokens and `.highlight` rules, so they look native in either theme.
- **Add** `docs/AGENTS.md` (a docs-prose voice guide, symlinked from `docs/CLAUDE.md`) and rewrite the workspace-builders intro to lead with the concept rather than the config keys.
- **Provision** the docs CI to render diagrams (`mmdc` + headless Chrome); without it the build still succeeds but degrades a diagram to its source text with a single warning.

## Changes by area

### Diagram extensions
- **`docs/_ext/mermaid_inline.py`**: `mermaid` directive → HTML write-phase visitor that shells to `mmdc`, content-hash-caches per theme, normalizes the SVG (unique id, explicit `width`/`height` from the `viewBox`, stripped `max-width`), and inlines light+dark variants toggled by CSS. Falls back to a `<pre>` with a one-time warning when the renderer is absent.
- **`docs/_ext/tmux_layout.py`**: `tmux-layout` directive. Computes filling geometry for tmux's named layouts (`even-vertical/horizontal`, `main-vertical/horizontal`, `tiled`) and emits one inline SVG — panes tile with single dividers, text top-left, pygments shell highlighting reusing furo's `.highlight` rules via `fill: currentColor`. Pure Python, no headless browser.
- **`docs/_static/css/gp-diagram.css`**, **`gp-tmux-layout.css`**: theme-adaptive styling (light/dark), code-block-matched fonts and backgrounds.

### Docs content & voice
- **`docs/configuration/workspace-builders.md`**: concept-first intro, a `tmuxp load → Workspace Builder → Attach tmux session` flow diagram, `libtmux` linked.
- **`docs/configuration/examples.md`**: the pane-layout examples now use `tmux-layout` (faithful tmux geometry) instead of ASCII art.
- **`docs/AGENTS.md`** + **`docs/CLAUDE.md`** (symlink): the docs prose voice guide.

### Toolchain & CI
- **`.github/workflows/docs.yml`**: Node/pnpm setup, a Puppeteer-browser cache, and a version-matched Chrome install before the docs build.
- **`docs/package.json`** + pnpm lock/workspace: pin `@mermaid-js/mermaid-cli`. `docs/node_modules` and the render cache are gitignored.

## Design decisions

- **Build-time SVG, not client-side mermaid**: client `mermaid.run()` renders after paint (layout shift + flash + per-diagram stagger) and, with gp-sphinx's synchronous View-Transition swap, the diagram would flash in after the crossfade. Build-time inline SVG paints with the page and rides SPA swaps untouched. The cost — owned explicitly — is a headless-Chrome build dependency (`mmdc`); there is no pure-Node path, since mermaid needs real browser text metrics.
- **`tmux-layout` is a Python directive, not a mermaid extension**: tmux layouts are pure geometry, where mermaid's browser-based layout engine is all cost and no benefit. A Python renderer needs no browser, and reusing furo's `.highlight` CSS makes the panes pixel-identical to the site's code blocks in both themes — which baked-in mermaid colours can't do.
- **Cache keyed on the full render config**: the on-disk render cache digest includes the theme variables and themeCSS, so a styling change busts the cache instead of serving a stale SVG.

## Test plan

- [x] `uv run ruff check . --fix && uv run ruff format .` — clean
- [x] `uv run mypy .` — clean
- [x] `uv run py.test --reruns 0` — green, including new `tests/test_docs_mermaid.py` and `tests/test_docs_tmux_layout.py` (NamedTuple-parametrized: SVG normalization, render cache idempotency, missing-renderer fallback, tmux geometry fills the screen, shell highlighting, the `setup()` contracts)
- [x] `just build-docs` — succeeds with no new warnings against the existing baseline; diagrams render as inline themed SVG on the workspace-builders and examples pages

## Setup required

The docs build environment must provide the diagram renderer, or mermaid diagrams degrade to text:

1. `pnpm -C docs install`
2. `pnpm -C docs rebuild puppeteer` (installs the version-matched headless Chrome)

The `docs.yml` workflow already does this for CI.