### PR TITLE
libtmux 0.61.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,26 @@ $ tmuxp@next load yoursession
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Dependencies
+
+#### Minimum `libtmux~=0.61.0` (was `~=0.60.0`) (#1074)
+
+Picks up libtmux 0.61.0, which hardens tmux 3.7 patch-line support:
+{meth}`~libtmux.Pane.break_pane` keeps tmux's own default window name on
+tmux 3.7a/3.7b instead of forcing `libtmux`, and the new
+{func}`~libtmux.common.get_version_str` exposes the raw tmux version
+string. tmux 3.2a-3.6 are unaffected.
+
+### What's new
+
+#### `tmuxp debug-info` reports the exact tmux patch release (#1074)
+
+`tmuxp debug-info` now shows tmux's full version, keeping the
+point-release letter (for example `3.7a`) that was previously normalized
+away to `3.7`. Because tmux patch releases can differ in behavior, the
+precise release is what a bug report needs. This reads libtmux 0.61.0's
+{func}`~libtmux.common.get_version_str`.
+
 ### Documentation
 
 #### Themed diagrams across the docs (#1071)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ include = [
   { path = "conftest.py", format = "sdist" },
 ]
 dependencies = [
-  "libtmux~=0.60.0",
+  "libtmux~=0.61.0",
   "PyYAML>=6.0"
 ]
 

--- a/src/tmuxp/cli/debug_info.py
+++ b/src/tmuxp/cli/debug_info.py
@@ -12,7 +12,7 @@ import sys
 import typing as t
 
 from libtmux.__about__ import __version__ as libtmux_version
-from libtmux.common import get_version, tmux_cmd
+from libtmux.common import get_version_str, tmux_cmd
 
 from tmuxp.__about__ import __version__
 from tmuxp._internal.private_path import PrivatePath, collapse_home_in_string
@@ -132,7 +132,7 @@ def _collect_debug_info() -> dict[str, t.Any]:
         },
         "python_version": " ".join(sys.version.split("\n")),
         "system_path": collapse_home_in_string(os.environ.get("PATH", "")),
-        "tmux_version": str(get_version()),
+        "tmux_version": get_version_str(),
         "libtmux_version": libtmux_version,
         "tmuxp_version": __version__,
         "tmux_path": _private(shutil.which("tmux")),

--- a/tests/cli/test_debug_info.py
+++ b/tests/cli/test_debug_info.py
@@ -167,3 +167,26 @@ def test_debug_info_json_paths_use_private_path(
     assert data["shell"] == "~/.local/bin/zsh", (
         f"Expected shell path to be masked with ~, got: {data['shell']}"
     )
+
+
+def test_debug_info_reports_raw_tmux_version(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """debug-info reports tmux's raw version, keeping the point-release suffix.
+
+    libtmux's ``get_version()`` strips the letter suffix (``"3.7a"`` -> ``"3.7"``)
+    for numeric comparison; ``get_version_str()`` keeps it. Bug reports want the
+    exact patch release, so debug-info reads the raw string verbatim.
+    """
+    monkeypatch.setenv("SHELL", "/bin/bash")
+    monkeypatch.setattr(
+        "tmuxp.cli.debug_info.get_version_str",
+        lambda *args, **kwargs: "3.7a",
+    )
+
+    cli.cli(["debug-info", "--json"])
+    output = capsys.readouterr().out
+    data = json.loads(output)
+
+    assert data["tmux_version"] == "3.7a"

--- a/uv.lock
+++ b/uv.lock
@@ -608,11 +608,11 @@ wheels = [
 
 [[package]]
 name = "libtmux"
-version = "0.60.0"
+version = "0.61.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/c2fc23e871855cb3feb5119ab3426656b2caa83f220fb6f1b7a770cb887e/libtmux-0.60.0.tar.gz", hash = "sha256:03d9740fd18090378a1f1a763403b127808b327b1466a1d3812c562f595ce06f", size = 527549, upload-time = "2026-06-28T21:19:35.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/c2/6abbac4420c35b3f1140c72607117236b160173f74fd86941f99b28375d5/libtmux-0.61.0.tar.gz", hash = "sha256:2d6081081a629b9236a36a64f874667533811d2ce5a1b0caa9c821f4d9d2e618", size = 546122, upload-time = "2026-07-04T12:57:36.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/c3/e524f498fe5dfc26c975ec8b52332fdd0b50e020f3ecc09423ba5d4ebc61/libtmux-0.60.0-py3-none-any.whl", hash = "sha256:a085e5653709d9e1c809c68f7daf1cd55c8af1ca938eb1e866388b9b13905ed3", size = 117368, upload-time = "2026-06-28T21:19:33.635Z" },
+    { url = "https://files.pythonhosted.org/packages/73/14/934d0d9076d1d46fcc71f3397daea7921363781674337084b15d1bbcbf84/libtmux-0.61.0-py3-none-any.whl", hash = "sha256:b9315db6600757f840a8f16438725103e579aaa4be3c32728c105f2c284330df", size = 118059, upload-time = "2026-07-04T12:57:34.598Z" },
 ]
 
 [[package]]
@@ -1685,7 +1685,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "libtmux", specifier = "~=0.60.0" },
+    { name = "libtmux", specifier = "~=0.61.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
## Summary

- **Bump** libtmux `~=0.60.0` → `~=0.61.0` — one upstream release, no breaking changes, tmux 3.2a-3.6 unaffected.
- **Improve** `tmuxp debug-info`: report the exact tmux patch release (`3.7a`/`3.7b`) instead of the numeric-normalized `3.7`, adopting libtmux 0.61.0's [`get_version_str()`](https://libtmux.git-pull.com/api/libtmux.common/#libtmux.common.get_version_str).
- **Inherit** libtmux's `Pane.break_pane()` fix on tmux 3.7a/3.7b — tmuxp never calls `break_pane`, so this is behavior-only with no code change.

## Upstream changes

### libtmux 0.61.0 (2026-07-04)

Hardens support for the tmux 3.7 patch line.

- **Fix:** `Pane.break_pane()` keeps tmux's own default window name on tmux 3.7a/3.7b instead of forcing `libtmux` (tmux-python/libtmux#699).
- **New API:** `get_version_str()` returns the raw tmux version with its point-release suffix intact (`"3.7a"`), where `get_version()` strips it for numeric comparison (tmux-python/libtmux#699).
- **Development:** libtmux's own test suite now passes against tmux 3.7a and 3.7b (tmux-python/libtmux#698).

Release: https://github.com/tmux-python/libtmux/releases/tag/v0.61.0
Changelog: https://libtmux.git-pull.com/history.html#libtmux-0-61-0-2026-07-04

## Changes by area

- **`pyproject.toml` / `uv.lock`**: bump the `libtmux` specifier and re-lock.
- **`src/tmuxp/cli/debug_info.py`**: `tmux_version` now reads `get_version_str()` instead of `str(get_version())`, preserving the patch letter.
- **`tests/cli/test_debug_info.py`**: add `test_debug_info_reports_raw_tmux_version`, which monkeypatches the helper to a known `3.7a` and asserts the raw string reaches the JSON output verbatim.
- **`CHANGES`**: 1.74.0 entry under `### Dependencies` (minimum bump) and `### What's new` (debug-info patch release).

## Design decisions

- **`get_version_str()` for reporting, `get_version()` for comparison.** `debug-info` exists for bug reports, where the faithful patch release matters. `plugin.py` deliberately keeps `get_version()` because it feeds `LooseVersion` constraint checks — a `LooseVersion("3.7b")` would compare the letter and break version-gate ordering. libtmux 0.61.0 splits these two functions for exactly this reason, and this PR follows that split rather than migrating both call sites.

## Before / After

On a tmux 3.7b host, `debug-info` previously normalized the version.

Before:

```console
$ tmuxp debug-info --json | jq .tmux_version
"3.7"
```

After:

```console
$ tmuxp debug-info --json | jq .tmux_version
"3.7b"
```

## Verification

`debug-info` no longer normalizes the version (expect zero matches):

```console
$ rg 'get_version\(\)' src/tmuxp/cli/debug_info.py
```

`plugin.py` intentionally keeps numeric comparison (expect a match):

```console
$ rg 'get_version\(\)' src/tmuxp/plugin.py
```

## Test plan

- [x] `uv run py.test` — full suite and doctests pass, including `test_debug_info_reports_raw_tmux_version`
- [x] `uv run mypy` — strict type check clean
- [x] `uv run ruff check .` and `uv run ruff format --check .` — clean
- [x] `just build-docs` — builds with no new warnings