### PR TITLE
feat: engine-ops async folding workspace builder

### DIFF
--- a/docs/topics/plugins.md
+++ b/docs/topics/plugins.md
@@ -64,6 +64,15 @@ is built — it augments, rather than replaces, the workspace's own
 `before_script` — and {meth}`~tmuxp.plugin.TmuxpPlugin.reattach` fires only
 when tmuxp re-attaches you to a session that already exists.
 
+Building several workspaces at once with `tmuxp load --parallel` or `--expand`
+folds them into one batched build, which exposes whole-session endpoints but no
+per-window boundary. Only {meth}`~tmuxp.plugin.TmuxpPlugin.before_script` runs
+there (once per built session); a plugin overriding a mid-build hook
+({meth}`~tmuxp.plugin.TmuxpPlugin.before_workspace_builder`,
+{meth}`~tmuxp.plugin.TmuxpPlugin.on_window_create`,
+{meth}`~tmuxp.plugin.TmuxpPlugin.after_window_finished`) is skipped with a
+warning. Load such a workspace on its own for the full hook sequence.
+
 ## Developing a plugin
 
 tmuxp expects a plugin to be a class in a Python submodule named `plugin`, inside

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,13 @@ lint = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# Development pin only (this branch): the engine-ops workspace API
+# (analyze/Workspace.abuild/WorkspaceSet, AsyncSubprocessEngine.for_server)
+# is unreleased. Points libtmux at the engine-ops branch so the
+# EngineOpsWorkspaceBuilder is importable. Not for release.
+[tool.uv.sources]
+libtmux = { git = "https://github.com/tmux-python/libtmux.git", branch = "engine-ops" }
+
 [tool.uv.exclude-newer-package]
 # git-pull packages release in lockstep with their workspaces, so a
 # fresh release blocking on the 3-day cooldown blocks every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ tmuxp = 'tmuxp:cli.cli'
 
 [project.entry-points."tmuxp.workspace_builders"]
 classic = "tmuxp.workspace.builder.classic:ClassicWorkspaceBuilder"
+engine-ops = "tmuxp.workspace.builder.engine_ops:EngineOpsWorkspaceBuilder"
 
 [dependency-groups]
 dev = [

--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import contextlib
 import importlib
 import logging
@@ -118,6 +119,9 @@ class CLILoadNamespace(argparse.Namespace):
     panel_lines: int | None
     no_progress: bool
     engine_ops: bool
+    parallel: bool
+    dry_run: bool
+    no_fold: bool
 
 
 def load_plugins(
@@ -859,6 +863,37 @@ def create_load_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
             "that folds a session's commands into a few tmux dispatches."
         ),
     )
+    parser.add_argument(
+        "--parallel",
+        dest="parallel",
+        action="store_true",
+        default=False,
+        help=(
+            "Build every WORKSPACE_FILE as one engine-ops workspace set: all "
+            "sessions compile into a single rebased, folded plan. Implies "
+            "--engine-ops; incompatible with -a/--append and -s."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=False,
+        help=(
+            "With --parallel, print the compiled tmux dispatch plan and exit "
+            "without touching the tmux server."
+        ),
+    )
+    parser.add_argument(
+        "--no-fold",
+        dest="no_fold",
+        action="store_true",
+        default=False,
+        help=(
+            "With --parallel, dispatch one tmux command per operation instead "
+            "of folding them into ;-chained batches (useful for debugging)."
+        ),
+    )
 
     try:
         import shtab
@@ -870,6 +905,139 @@ def create_load_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         pass
 
     return parser
+
+
+def _load_parallel(
+    args: CLILoadNamespace,
+    cli_colors: Colors,
+    parser: argparse.ArgumentParser | None = None,
+) -> None:
+    """Build every WORKSPACE_FILE as one engine-ops workspace set.
+
+    ``--parallel`` lowers all workspace files to libtmux's declarative
+    :class:`~libtmux.experimental.workspace.ir.Workspace` IR, groups them into a
+    single :class:`~libtmux.experimental.workspace.sets.WorkspaceSet`, and
+    ``abuild``s the whole set as one rebased, folded plan -- so N sessions
+    render in a few ``;``-chained tmux dispatches sharing one preflight, instead
+    of one detached ``load`` per file.
+
+    It implies the engine-ops backend. ``--append`` and ``-s`` describe
+    single-session semantics that don't compose with a multi-session set, so
+    they are rejected. Plugins are not run on this path (a known limitation of
+    the folded set build); use a plain load when you need them.
+
+    Parameters
+    ----------
+    args : CLILoadNamespace
+        Parsed ``tmuxp load`` arguments.
+    cli_colors : :class:`~tmuxp._internal.colors.Colors`
+        Colors instance for styled output.
+    parser : :class:`argparse.ArgumentParser`, optional
+        The load subparser, used only to print help on bad input.
+
+    Examples
+    --------
+    >>> from tmuxp.cli.load import _load_parallel
+    >>> callable(_load_parallel)
+    True
+    """
+    from libtmux.experimental.engines import AsyncSubprocessEngine
+    from libtmux.experimental.ops import SequentialPlanner
+    from libtmux.experimental.workspace import WorkspaceSet, analyze
+
+    if args.append:
+        tmuxp_echo(
+            cli_colors.error("[Error]")
+            + " --parallel cannot be combined with -a/--append",
+        )
+        sys.exit(1)
+    if args.new_session_name:
+        tmuxp_echo(
+            cli_colors.error("[Error]") + " --parallel cannot be combined with -s",
+        )
+        sys.exit(1)
+
+    # Lower each file to a Workspace IR node, mirroring load_workspace's
+    # read -> expand(cwd) -> trickle pipeline so relative paths resolve the same.
+    workspaces = []
+    for raw_file in args.workspace_files:
+        workspace_file = pathlib.Path(
+            find_workspace_file(
+                raw_file,
+                workspace_dir=get_workspace_dir(),
+            ),
+        )
+        raw_workspace = config_reader.ConfigReader._from_file(workspace_file) or {}
+        expanded = loader.expand(
+            raw_workspace,
+            cwd=os.path.dirname(workspace_file),
+        )
+        expanded = loader.trickle(expanded)
+        if not expanded:
+            tmuxp_echo(
+                cli_colors.warning("[Warning]")
+                + f" {PrivatePath(workspace_file)} is empty; skipping",
+            )
+            continue
+        workspaces.append(analyze(expanded))
+
+    if not workspaces:
+        tmuxp_echo(cli_colors.error("[Error]") + " no workspaces to build")
+        sys.exit(1)
+
+    try:
+        ws_set = WorkspaceSet(workspaces)
+    except ValueError as error:
+        # Duplicate session names across the set are unbuildable.
+        tmuxp_echo(cli_colors.error("[Error]") + f" {error}")
+        sys.exit(1)
+
+    shutil.which("tmux")  # raise exception if tmux not found
+
+    # --dry-run: render the compiled plan without touching the tmux server.
+    if args.dry_run:
+        compiled = ws_set.compile()
+        tmuxp_echo(cli_colors.info("[Dry run]") + " compiled tmux plan:")
+        for idx, row in enumerate(compiled.plan.preview(), start=1):
+            # Forward-ref rows resolve to real args only at execution time.
+            rendered = "<deferred>" if row is None else " ".join(row)
+            tmuxp_echo(f"  {idx:>3}  {rendered}")
+        return
+
+    server = Server(
+        socket_name=args.socket_name,
+        socket_path=args.socket_path,
+        config_file=args.tmux_config_file,
+        colors=args.colors,
+    )
+
+    planner = SequentialPlanner() if args.no_fold else None
+    engine = AsyncSubprocessEngine.for_server(server)
+    try:
+        result = asyncio.run(ws_set.abuild(engine, planner=planner))
+    except FileExistsError as error:
+        # A session already exists and its on_exists policy is 'error'.
+        tmuxp_echo(cli_colors.error("[Error]") + f" {error}")
+        sys.exit(1)
+
+    checkmark = cli_colors.success("✓")
+    for name in result.sessions:
+        tmuxp_echo(f"{checkmark} built {cli_colors.highlight(name)}")
+    for name in result.reused:
+        tmuxp_echo(cli_colors.muted(f"reused {name}"))
+
+    # Attach the last declared session unless detached or unavailable, matching
+    # the sequential path's "last file attaches" convention.
+    if args.detached:
+        return
+    last_name = workspaces[-1].name
+    session = server.sessions.get(session_name=last_name, default=None)
+    if session is None:
+        return
+    if "TMUX" in os.environ:
+        session.switch_client()
+    else:
+        session.attach()
 
 
 def command_load(
@@ -911,6 +1079,19 @@ def command_load(
         if parser is not None:
             parser.print_help()
         sys.exit()
+        return
+
+    # --dry-run/--no-fold only mean something for the workspace-set build; guard
+    # against the footgun where `load --dry-run foo` would silently build foo.
+    if (args.dry_run or args.no_fold) and not args.parallel:
+        tmuxp_echo(
+            cli_colors.error("[Error]") + " --dry-run and --no-fold require --parallel",
+        )
+        sys.exit(1)
+
+    # --parallel builds every file as one folded engine-ops workspace set.
+    if args.parallel:
+        _load_parallel(args, cli_colors, parser)
         return
 
     last_idx = len(args.workspace_files) - 1

--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -121,6 +121,7 @@ class CLILoadNamespace(argparse.Namespace):
     panel_lines: int | None
     no_progress: bool
     engine_ops: bool
+    engine_ops_engine: str
     parallel: bool
     dry_run: bool
     no_fold: bool
@@ -467,6 +468,7 @@ def load_workspace(
     panel_lines: int | None = None,
     no_progress: bool = False,
     builder_override: str | None = None,
+    engine_ops_engine: str = "subprocess",
 ) -> Session | None:
     """Entrypoint for ``tmuxp load``, load a tmuxp "workspace" session via config file.
 
@@ -592,6 +594,7 @@ def load_workspace(
     # already names one; resolve_builder_class reads the workspace_builder key.
     if builder_override:
         expanded_workspace["workspace_builder"] = builder_override
+        expanded_workspace["engine_ops_engine"] = engine_ops_engine
 
     t = Server(  # create tmux server object
         socket_name=socket_name,
@@ -867,6 +870,17 @@ def create_load_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         ),
     )
     parser.add_argument(
+        "--engine-ops-engine",
+        dest="engine_ops_engine",
+        choices=("subprocess", "control_mode"),
+        default="subprocess",
+        help=(
+            "Async engine for --engine-ops: 'subprocess' (default, one tmux "
+            "fork per dispatch) or 'control_mode' (one persistent tmux -C "
+            "connection -- faster for larger workspaces)."
+        ),
+    )
+    parser.add_argument(
         "--parallel",
         dest="parallel",
         action="store_true",
@@ -1120,7 +1134,10 @@ def _load_parallel(
     >>> callable(_load_parallel)
     True
     """
-    from libtmux.experimental.engines import AsyncSubprocessEngine
+    from libtmux.experimental.engines import (
+        AsyncControlModeEngine,
+        AsyncSubprocessEngine,
+    )
     from libtmux.experimental.ops import SequentialPlanner
     from libtmux.experimental.workspace import (
         Workspace,
@@ -1242,9 +1259,18 @@ def _load_parallel(
     )
 
     planner = SequentialPlanner() if args.no_fold else None
-    engine = AsyncSubprocessEngine.for_server(server)
+
+    async def _abuild() -> t.Any:
+        # control_mode uses one persistent tmux -C (async context manager);
+        # subprocess forks per dispatch (a plain engine).
+        if args.engine_ops_engine == "control_mode":
+            async with AsyncControlModeEngine.for_server(server) as engine:
+                return await ws_set.abuild(engine, planner=planner)
+        subproc = AsyncSubprocessEngine.for_server(server)
+        return await ws_set.abuild(subproc, planner=planner)
+
     try:
-        result = asyncio.run(ws_set.abuild(engine, planner=planner))
+        result = asyncio.run(_abuild())
     except FileExistsError as error:
         # A session already exists and its on_exists policy is 'error'.
         tmuxp_echo(cli_colors.error("[Error]") + f" {error}")
@@ -1366,4 +1392,5 @@ def command_load(
             panel_lines=args.panel_lines,
             no_progress=args.no_progress,
             builder_override="engine-ops" if args.engine_ops else None,
+            engine_ops_engine=args.engine_ops_engine,
         )

--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import contextlib
 import importlib
+import itertools
 import logging
 import os
 import pathlib
@@ -122,6 +123,7 @@ class CLILoadNamespace(argparse.Namespace):
     parallel: bool
     dry_run: bool
     no_fold: bool
+    expand: list[str] | None
 
 
 def load_plugins(
@@ -894,6 +896,18 @@ def create_load_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
             "of folding them into ;-chained batches (useful for debugging)."
         ),
     )
+    parser.add_argument(
+        "--expand",
+        dest="expand",
+        metavar="KEY=V1,V2",
+        action="append",
+        default=None,
+        help=(
+            "Expand ONE workspace file into a session per value by substituting "
+            "$KEY placeholders (e.g. session_name: app-$env). Repeat for a "
+            "matrix (Cartesian product). Implies a folded set build."
+        ),
+    )
 
     try:
         import shtab
@@ -905,6 +919,62 @@ def create_load_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         pass
 
     return parser
+
+
+def _parse_expand_specs(specs: list[str]) -> list[dict[str, str]]:
+    """Turn ``KEY=V1,V2`` ``--expand`` specs into variant dicts.
+
+    Each spec is one axis; multiple axes form a matrix (Cartesian product). The
+    variant dicts feed :func:`libtmux.experimental.workspace.expand`, which
+    substitutes ``$KEY`` placeholders in the base workspace.
+
+    Parameters
+    ----------
+    specs : list of str
+        Raw ``KEY=V1,V2`` strings, one per ``--expand`` flag.
+
+    Returns
+    -------
+    list of dict
+        One ``{key: value}`` variant per point in the matrix.
+
+    Raises
+    ------
+    ValueError
+        If a spec lacks ``=``, has an empty key, or lists no values.
+
+    Examples
+    --------
+    A single axis yields one variant per value:
+
+    >>> from tmuxp.cli.load import _parse_expand_specs
+    >>> _parse_expand_specs(["env=dev,prod"])
+    [{'env': 'dev'}, {'env': 'prod'}]
+
+    Two axes form a matrix:
+
+    >>> variants = _parse_expand_specs(["env=dev,prod", "region=us,eu"])
+    >>> len(variants)
+    4
+    >>> variants[0], variants[-1]
+    ({'env': 'dev', 'region': 'us'}, {'env': 'prod', 'region': 'eu'})
+    """
+    axes: list[tuple[str, list[str]]] = []
+    for spec in specs:
+        key, sep, raw = spec.partition("=")
+        if not sep or not key.strip():
+            msg = f"invalid --expand spec {spec!r}; expected KEY=V1,V2"
+            raise ValueError(msg)
+        values = [v.strip() for v in raw.split(",") if v.strip()]
+        if not values:
+            msg = f"invalid --expand spec {spec!r}; no values after '='"
+            raise ValueError(msg)
+        axes.append((key.strip(), values))
+    keys = [key for key, _ in axes]
+    value_lists = [values for _, values in axes]
+    return [
+        dict(zip(keys, combo, strict=True)) for combo in itertools.product(*value_lists)
+    ]
 
 
 def _load_parallel(
@@ -920,6 +990,11 @@ def _load_parallel(
     ``abuild``s the whole set as one rebased, folded plan -- so N sessions
     render in a few ``;``-chained tmux dispatches sharing one preflight, instead
     of one detached ``load`` per file.
+
+    With ``--expand KEY=V1,V2`` a single file is instead expanded into one
+    session per value (a matrix, over multiple ``--expand`` axes) by
+    substituting ``$KEY`` placeholders; the rendered variants build as the same
+    kind of folded set.
 
     It implies the engine-ops backend. ``--append`` and ``-s`` describe
     single-session semantics that don't compose with a multi-session set, so
@@ -943,7 +1018,12 @@ def _load_parallel(
     """
     from libtmux.experimental.engines import AsyncSubprocessEngine
     from libtmux.experimental.ops import SequentialPlanner
-    from libtmux.experimental.workspace import WorkspaceSet, analyze
+    from libtmux.experimental.workspace import (
+        Workspace,
+        WorkspaceSet,
+        analyze,
+        expand as expand_variants,
+    )
 
     if args.append:
         tmuxp_echo(
@@ -957,29 +1037,53 @@ def _load_parallel(
         )
         sys.exit(1)
 
-    # Lower each file to a Workspace IR node, mirroring load_workspace's
-    # read -> expand(cwd) -> trickle pipeline so relative paths resolve the same.
-    workspaces = []
-    for raw_file in args.workspace_files:
-        workspace_file = pathlib.Path(
-            find_workspace_file(
-                raw_file,
-                workspace_dir=get_workspace_dir(),
-            ),
+    def _lower(raw_file: str) -> tuple[dict[str, t.Any], pathlib.Path]:
+        """Resolve, read, and expand one file to a trickled config dict.
+
+        Mirrors load_workspace's read -> expand(cwd) -> trickle pipeline so
+        relative paths resolve identically on the set path.
+        """
+        path = pathlib.Path(
+            find_workspace_file(raw_file, workspace_dir=get_workspace_dir()),
         )
-        raw_workspace = config_reader.ConfigReader._from_file(workspace_file) or {}
-        expanded = loader.expand(
-            raw_workspace,
-            cwd=os.path.dirname(workspace_file),
-        )
-        expanded = loader.trickle(expanded)
+        raw = config_reader.ConfigReader._from_file(path) or {}
+        expanded = loader.trickle(loader.expand(raw, cwd=os.path.dirname(path)))
+        return expanded, path
+
+    workspaces: list[Workspace]
+    if args.expand:
+        # Matrix mode: expand ONE base file into a session per variant.
+        if len(args.workspace_files) != 1:
+            tmuxp_echo(
+                cli_colors.error("[Error]")
+                + " --expand takes exactly one workspace file",
+            )
+            sys.exit(1)
+        try:
+            variants = _parse_expand_specs(args.expand)
+        except ValueError as error:
+            tmuxp_echo(cli_colors.error("[Error]") + f" {error}")
+            sys.exit(1)
+        expanded, path = _lower(args.workspace_files[0])
         if not expanded:
             tmuxp_echo(
-                cli_colors.warning("[Warning]")
-                + f" {PrivatePath(workspace_file)} is empty; skipping",
+                cli_colors.error("[Error]")
+                + f" {PrivatePath(path)} is empty or parsed no workspace data",
             )
-            continue
-        workspaces.append(analyze(expanded))
+            sys.exit(1)
+        workspaces = list(expand_variants(analyze(expanded), variants))
+    else:
+        # Multi-file mode: one session per file.
+        workspaces = []
+        for raw_file in args.workspace_files:
+            expanded, path = _lower(raw_file)
+            if not expanded:
+                tmuxp_echo(
+                    cli_colors.warning("[Warning]")
+                    + f" {PrivatePath(path)} is empty; skipping",
+                )
+                continue
+            workspaces.append(analyze(expanded))
 
     if not workspaces:
         tmuxp_echo(cli_colors.error("[Error]") + " no workspaces to build")
@@ -1081,16 +1185,20 @@ def command_load(
         sys.exit()
         return
 
-    # --dry-run/--no-fold only mean something for the workspace-set build; guard
-    # against the footgun where `load --dry-run foo` would silently build foo.
-    if (args.dry_run or args.no_fold) and not args.parallel:
+    # The set-build path is selected by --parallel (many files) or --expand
+    # (one file, many variants); --expand implies it.
+    _set_build = args.parallel or bool(args.expand)
+
+    # --dry-run/--no-fold only mean something for the set build; guard against
+    # the footgun where `load --dry-run foo` would silently build foo.
+    if (args.dry_run or args.no_fold) and not _set_build:
         tmuxp_echo(
-            cli_colors.error("[Error]") + " --dry-run and --no-fold require --parallel",
+            cli_colors.error("[Error]")
+            + " --dry-run and --no-fold require --parallel or --expand",
         )
         sys.exit(1)
 
-    # --parallel builds every file as one folded engine-ops workspace set.
-    if args.parallel:
+    if _set_build:
         _load_parallel(args, cli_colors, parser)
         return
 

--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -117,6 +117,7 @@ class CLILoadNamespace(argparse.Namespace):
     progress_format: str | None
     panel_lines: int | None
     no_progress: bool
+    engine_ops: bool
 
 
 def load_plugins(
@@ -458,6 +459,7 @@ def load_workspace(
     progress_format: str | None = None,
     panel_lines: int | None = None,
     no_progress: bool = False,
+    builder_override: str | None = None,
 ) -> Session | None:
     """Entrypoint for ``tmuxp load``, load a tmuxp "workspace" session via config file.
 
@@ -578,6 +580,11 @@ def load_workspace(
 
     # propagate workspace inheritance (e.g. session -> window, window -> pane)
     expanded_workspace = loader.trickle(expanded_workspace)
+
+    # Select an alternate builder backend (e.g. --engine-ops) unless the config
+    # already names one; resolve_builder_class reads the workspace_builder key.
+    if builder_override:
+        expanded_workspace["workspace_builder"] = builder_override
 
     t = Server(  # create tmux server object
         socket_name=socket_name,
@@ -842,6 +849,16 @@ def create_load_subparser(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         default=False,
         help=("Disable the animated progress spinner. Env: TMUXP_PROGRESS=0"),
     )
+    parser.add_argument(
+        "--engine-ops",
+        dest="engine_ops",
+        action="store_true",
+        default=False,
+        help=(
+            "Build with the experimental engine-ops backend: an async builder "
+            "that folds a session's commands into a few tmux dispatches."
+        ),
+    )
 
     try:
         import shtab
@@ -927,4 +944,5 @@ def command_load(
             progress_format=args.progress_format,
             panel_lines=args.panel_lines,
             no_progress=args.no_progress,
+            builder_override="engine-ops" if args.engine_ops else None,
         )

--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -19,6 +19,7 @@ from libtmux.server import Server
 from tmuxp import exc, log, util
 from tmuxp._internal import config_reader
 from tmuxp._internal.private_path import PrivatePath
+from tmuxp.plugin import TmuxpPlugin
 from tmuxp.workspace import loader
 from tmuxp.workspace.builder import (
     WorkspaceBuilderProtocol,
@@ -977,6 +978,100 @@ def _parse_expand_specs(specs: list[str]) -> list[dict[str, str]]:
     ]
 
 
+#: Plugin hooks the classic builder fires *between* window/pane creation. The
+#: folded set build has no per-window boundary to run them at, so they are
+#: skipped with a warning; a sequential ``load`` runs them.
+_SET_UNSUPPORTED_HOOKS = (
+    "before_workspace_builder",
+    "on_window_create",
+    "after_window_finished",
+)
+
+
+class _SetPlugins(t.NamedTuple):
+    """One file's loaded plugins plus the import sandbox they resolve under."""
+
+    builder_paths: list[pathlib.Path]
+    plugins: list[t.Any]
+
+
+def _load_set_plugins(
+    expanded: dict[str, t.Any],
+    workspace_file: pathlib.Path,
+    cli_colors: Colors,
+) -> _SetPlugins:
+    """Load a file's plugins for a set build, warning on unsupported hooks.
+
+    Loads inside the file's import sandbox so the version-compat gate and any
+    skip prompt run *before* the fold (matching the sequential path), and warns
+    once per plugin that overrides a mid-build hook the folded build can't run.
+
+    Examples
+    --------
+    >>> from tmuxp.cli.load import _load_set_plugins
+    >>> callable(_load_set_plugins)
+    True
+    """
+    if not expanded.get("plugins"):
+        return _SetPlugins([], [])
+    builder_paths = resolve_builder_paths(expanded, workspace_file)
+    with prepended_sys_path(builder_paths):
+        plugins = load_plugins(expanded, colors=cli_colors)
+    for plugin in plugins:
+        skipped = [
+            hook
+            for hook in _SET_UNSUPPORTED_HOOKS
+            if getattr(type(plugin), hook) is not getattr(TmuxpPlugin, hook)
+        ]
+        if skipped:
+            logger.warning(
+                "plugin mid-build hooks skipped on set build; run without "
+                "--parallel/--expand for full plugin support",
+                extra={
+                    "plugin": type(plugin).__name__,
+                    "skipped_hooks": ",".join(skipped),
+                },
+            )
+    return _SetPlugins(builder_paths, plugins)
+
+
+def _run_set_before_script(
+    server: Server,
+    session_plugins: dict[str, _SetPlugins],
+    built: list[str],
+) -> None:
+    """Run each built session's ``before_script`` plugin hooks post-build.
+
+    The folded set path's analogue of :func:`_setup_plugins`. Hooks run after
+    ``abuild`` returns, by name lookup on materialized sessions, so the fold is
+    untouched. A hook that raises is logged and skipped -- one plugin failure
+    must not tear down the other already-built sessions.
+
+    Examples
+    --------
+    >>> from tmuxp.cli.load import _run_set_before_script
+    >>> callable(_run_set_before_script)
+    True
+    """
+    for name in built:
+        binding = session_plugins.get(name)
+        if binding is None:
+            continue
+        session = server.sessions.get(session_name=name, default=None)
+        if session is None:
+            continue
+        with prepended_sys_path(binding.builder_paths):
+            for plugin in binding.plugins:
+                try:
+                    plugin.before_script(session)
+                except Exception:  # noqa: PERF203 - isolate each plugin's hook
+                    logger.warning(
+                        "plugin before_script failed on set build",
+                        extra={"tmux_session": name, "plugin": type(plugin).__name__},
+                        exc_info=True,
+                    )
+
+
 def _load_parallel(
     args: CLILoadNamespace,
     cli_colors: Colors,
@@ -998,8 +1093,17 @@ def _load_parallel(
 
     It implies the engine-ops backend. ``--append`` and ``-s`` describe
     single-session semantics that don't compose with a multi-session set, so
-    they are rejected. Plugins are not run on this path (a known limitation of
-    the folded set build); use a plain load when you need them.
+    they are rejected.
+
+    Plugin support is partial by design: each built session's ``before_script``
+    hook runs post-build (the fold exposes whole-session endpoints, not
+    per-window boundaries). The mid-build hooks (``before_workspace_builder``,
+    ``on_window_create``, ``after_window_finished``) can't run without unfolding
+    the plan, so a plugin overriding one is skipped with a warning; the
+    ``reattach`` hook isn't fired here (as on any fresh sequential load). Unlike
+    the sequential path, a ``before_script`` that raises is logged and skipped
+    rather than surfaced -- one plugin must not tear down the other built
+    sessions. Use a sequential ``load`` when you need full plugin semantics.
 
     Parameters
     ----------
@@ -1050,6 +1154,10 @@ def _load_parallel(
         expanded = loader.trickle(loader.expand(raw, cwd=os.path.dirname(path)))
         return expanded, path
 
+    # session name -> (expanded config, source file), captured purely at
+    # lowering time so plugins can be loaded per built session later without
+    # re-reading files. (The IR drops the "plugins" key and the source path.)
+    session_sources: dict[str, tuple[dict[str, t.Any], pathlib.Path]] = {}
     workspaces: list[Workspace]
     if args.expand:
         # Matrix mode: expand ONE base file into a session per variant.
@@ -1072,6 +1180,8 @@ def _load_parallel(
             )
             sys.exit(1)
         workspaces = list(expand_variants(analyze(expanded), variants))
+        for ws in workspaces:
+            session_sources[ws.name] = (expanded, path)
     else:
         # Multi-file mode: one session per file.
         workspaces = []
@@ -1083,7 +1193,9 @@ def _load_parallel(
                     + f" {PrivatePath(path)} is empty; skipping",
                 )
                 continue
-            workspaces.append(analyze(expanded))
+            ws = analyze(expanded)
+            workspaces.append(ws)
+            session_sources[ws.name] = (expanded, path)
 
     if not workspaces:
         tmuxp_echo(cli_colors.error("[Error]") + " no workspaces to build")
@@ -1108,6 +1220,20 @@ def _load_parallel(
             tmuxp_echo(f"  {idx:>3}  {rendered}")
         return
 
+    # Load plugins BEFORE the fold so a version-incompatible plugin refuses up
+    # front (as the sequential path does), not after N sessions already exist.
+    # Memoized per file so --expand variants sharing one file load (and warn)
+    # once. Only post-build hooks run on the set path (see the docstring).
+    session_plugins: dict[str, _SetPlugins] = {}
+    loaded: dict[pathlib.Path, _SetPlugins] = {}
+    for name, (expanded, path) in session_sources.items():
+        if not expanded.get("plugins"):
+            continue
+        if path not in loaded:
+            loaded[path] = _load_set_plugins(expanded, path, cli_colors)
+        if loaded[path].plugins:
+            session_plugins[name] = loaded[path]
+
     server = Server(
         socket_name=args.socket_name,
         socket_path=args.socket_path,
@@ -1129,6 +1255,12 @@ def _load_parallel(
         tmuxp_echo(f"{checkmark} built {cli_colors.highlight(name)}")
     for name in result.reused:
         tmuxp_echo(cli_colors.muted(f"reused {name}"))
+
+    # Post-build before_script hooks on freshly built sessions (not reused).
+    if session_plugins:
+        reused = set(result.reused)
+        built = [name for name in result.sessions if name not in reused]
+        _run_set_before_script(server, session_plugins, built)
 
     # Attach the last declared session unless detached or unavailable, matching
     # the sequential path's "last file attaches" convention.

--- a/src/tmuxp/workspace/builder/engine_ops.py
+++ b/src/tmuxp/workspace/builder/engine_ops.py
@@ -21,7 +21,10 @@ import asyncio
 import typing as t
 
 from libtmux._internal.query_list import ObjectDoesNotExist
-from libtmux.experimental.engines import AsyncSubprocessEngine
+from libtmux.experimental.engines import (
+    AsyncControlModeEngine,
+    AsyncSubprocessEngine,
+)
 from libtmux.experimental.workspace import analyze
 from libtmux.experimental.workspace.events import (
     PaneCreated,
@@ -144,8 +147,9 @@ class EngineOpsWorkspaceBuilder:
         if append:
             msg = "engine-ops builder does not support append; use the classic builder"
             raise NotImplementedError(msg)
-        workspace = analyze(self.session_config)
-        engine = AsyncSubprocessEngine.for_server(self.server)
+        config = dict(self.session_config)
+        engine_kind = config.pop("engine_ops_engine", "subprocess")
+        workspace = analyze(config)
         windows = self.session_config.get("windows", [])
 
         async def _bridge(event: BuildEvent) -> None:
@@ -164,7 +168,17 @@ class EngineOpsWorkspaceBuilder:
                 )
             self.on_build_event(payload)
 
-        asyncio.run(workspace.abuild(engine, on_event=_bridge))
+        async def _run() -> None:
+            # control_mode uses one persistent ``tmux -C`` (an async context
+            # manager); subprocess forks per dispatch (a plain engine).
+            if engine_kind == "control_mode":
+                async with AsyncControlModeEngine.for_server(self.server) as engine:
+                    await workspace.abuild(engine, on_event=_bridge)
+            else:
+                subproc = AsyncSubprocessEngine.for_server(self.server)
+                await workspace.abuild(subproc, on_event=_bridge)
+
+        asyncio.run(_run())
 
         built = self.server.sessions.get(session_name=workspace.name)
         assert built is not None

--- a/src/tmuxp/workspace/builder/engine_ops.py
+++ b/src/tmuxp/workspace/builder/engine_ops.py
@@ -146,11 +146,23 @@ class EngineOpsWorkspaceBuilder:
             raise NotImplementedError(msg)
         workspace = analyze(self.session_config)
         engine = AsyncSubprocessEngine.for_server(self.server)
+        windows = self.session_config.get("windows", [])
 
         async def _bridge(event: BuildEvent) -> None:
             name = _EVENT_NAMES.get(type(event))
-            if name is not None and self.on_build_event is not None:
-                self.on_build_event({"event": name})
+            if name is None or self.on_build_event is None:
+                return
+            payload: dict[str, t.Any] = {"event": name}
+            if isinstance(event, SessionCreated):
+                # The CLI progress spinner reads these keys on session_created;
+                # they come from the config since the folded build has no live
+                # per-window boundary to count from.
+                payload["name"] = workspace.name
+                payload["window_total"] = len(windows)
+                payload["session_pane_total"] = sum(
+                    len(w.get("panes", [])) for w in windows
+                )
+            self.on_build_event(payload)
 
         asyncio.run(workspace.abuild(engine, on_event=_bridge))
 

--- a/src/tmuxp/workspace/builder/engine_ops.py
+++ b/src/tmuxp/workspace/builder/engine_ops.py
@@ -1,0 +1,161 @@
+"""An async, folding workspace builder backed by libtmux's engine-ops.
+
+:class:`EngineOpsWorkspaceBuilder` is an opt-in
+:class:`~tmuxp.workspace.builder.protocol.WorkspaceBuilderProtocol` that lowers an
+expanded workspace ``dict`` to libtmux's declarative
+:class:`~libtmux.experimental.workspace.ir.Workspace` and ``abuild``s it
+asynchronously. The build *folds*: a multi-pane window's commands collapse into a
+handful of ``;``-chained tmux dispatches instead of one ``send-keys`` per line,
+so a session renders in a few round-trips rather than dozens.
+
+Select it with the ``workspace_builder: engine-ops`` config key or ``tmuxp load
+--engine-ops``.
+
+The engine-ops workspace API is unreleased (``libtmux.experimental``); this
+module is usable only with the branch pin in ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import typing as t
+
+from libtmux._internal.query_list import ObjectDoesNotExist
+from libtmux.experimental.engines import AsyncSubprocessEngine
+from libtmux.experimental.workspace import analyze
+from libtmux.experimental.workspace.events import (
+    PaneCreated,
+    SessionCreated,
+    WindowCreated,
+    WorkspaceBuilt,
+)
+from libtmux.server import Server
+
+from tmuxp import exc
+from tmuxp.util import get_current_pane
+
+if t.TYPE_CHECKING:
+    from libtmux.experimental.workspace.events import BuildEvent
+    from libtmux.session import Session
+
+#: Map an engine-ops structural event to the classic ``on_build_event`` name, so
+#: a CLI progress UI written against the classic builder keeps working.
+_EVENT_NAMES: dict[type[BuildEvent], str] = {
+    SessionCreated: "session_created",
+    WindowCreated: "window_done",
+    PaneCreated: "pane_created",
+    WorkspaceBuilt: "workspace_built",
+}
+
+
+class EngineOpsWorkspaceBuilder:
+    """Build a workspace by folding it into a few async tmux dispatches.
+
+    A drop-in builder that lowers the expanded config to libtmux's
+    :class:`~libtmux.experimental.workspace.ir.Workspace` IR and ``abuild``s it;
+    the result matches the classic builder's session/windows/panes, only the
+    dispatch count differs.
+
+    Selecting it by config key resolves to this class (a live build needs a
+    server; see ``tests/workspace/test_builder_engine_ops.py``):
+
+    Examples
+    --------
+    >>> from tmuxp.workspace.builder.registry import resolve_builder_class
+    >>> resolve_builder_class({"workspace_builder": "engine-ops"}) is (
+    ...     EngineOpsWorkspaceBuilder
+    ... )
+    True
+    """
+
+    plugins: list[t.Any]
+    on_progress: t.Callable[[str], None] | None
+    on_before_script: t.Callable[[], None] | None
+    on_script_output: t.Callable[[str], None] | None
+    on_build_event: t.Callable[[dict[str, t.Any]], None] | None
+
+    def __init__(
+        self,
+        session_config: dict[str, t.Any],
+        server: Server,
+        plugins: list[t.Any] | None = None,
+        on_progress: t.Callable[[str], None] | None = None,
+        on_before_script: t.Callable[[], None] | None = None,
+        on_script_output: t.Callable[[str], None] | None = None,
+        on_build_event: t.Callable[[dict[str, t.Any]], None] | None = None,
+    ) -> None:
+        """Construct from an expanded workspace and a tmux server."""
+        if not session_config:
+            raise exc.EmptyWorkspaceException
+        assert isinstance(server, Server)
+        self.session_config = session_config
+        self.server = server
+        self.plugins = plugins if plugins is not None else []
+        self.on_progress = on_progress
+        self.on_before_script = on_before_script
+        self.on_script_output = on_script_output
+        self.on_build_event = on_build_event
+        self._session: Session | None = None
+        if self.session_exists(session_config["session_name"]):
+            try:
+                self._session = server.sessions.get(
+                    session_name=session_config["session_name"],
+                )
+            except ObjectDoesNotExist:
+                self._session = None
+
+    @property
+    def session(self) -> Session:
+        """Return the tmux session the builder created or populated."""
+        if self._session is None:
+            raise exc.SessionMissingWorkspaceException
+        return self._session
+
+    def session_exists(self, session_name: str) -> bool:
+        """Return ``True`` if a session with ``session_name`` already exists."""
+        assert isinstance(session_name, str)
+        if not self.server.has_session(session_name):
+            return False
+        try:
+            self.server.sessions.get(session_name=session_name)
+        except ObjectDoesNotExist:
+            return False
+        return True
+
+    def find_current_attached_session(self) -> Session:
+        """Return the session currently attached within ``$TMUX``."""
+        current_active_pane = get_current_pane(self.server)
+        if current_active_pane is None:
+            raise exc.ActiveSessionMissingWorkspaceException
+        return next(
+            s
+            for s in self.server.sessions
+            if s.session_id == current_active_pane.session_id
+        )
+
+    def build(self, session: Session | None = None, append: bool = False) -> None:
+        """Build the workspace by folding it into a few async dispatches.
+
+        Lowers the config to a :class:`~..ir.Workspace`, ``abuild``s it over an
+        :class:`~libtmux.experimental.engines.AsyncSubprocessEngine` bound to the
+        server, and populates :attr:`session`. ``append`` is not supported (the
+        IR always emits ``new-session``); use the classic builder for it.
+        """
+        if append:
+            msg = "engine-ops builder does not support append; use the classic builder"
+            raise NotImplementedError(msg)
+        workspace = analyze(self.session_config)
+        engine = AsyncSubprocessEngine.for_server(self.server)
+
+        async def _bridge(event: BuildEvent) -> None:
+            name = _EVENT_NAMES.get(type(event))
+            if name is not None and self.on_build_event is not None:
+                self.on_build_event({"event": name})
+
+        asyncio.run(workspace.abuild(engine, on_event=_bridge))
+
+        built = self.server.sessions.get(session_name=workspace.name)
+        assert built is not None
+        self._session = built
+        if self.on_progress is not None:
+            self.on_progress("Workspace built")

--- a/tests/cli/test_load_parallel.py
+++ b/tests/cli/test_load_parallel.py
@@ -8,6 +8,7 @@ import typing as t
 import pytest
 
 from tmuxp import cli
+from tmuxp.cli.load import _parse_expand_specs
 
 if t.TYPE_CHECKING:
     import pathlib
@@ -208,3 +209,114 @@ def test_parallel_rejects_incompatible_flags(
         assert server.sessions.get(session_name="ppar-reject", default=None) is None
     finally:
         _kill(server, "ppar-reject")
+
+
+def test_parse_expand_specs_matrix() -> None:
+    """Multiple --expand axes produce the Cartesian product of variants."""
+    variants = _parse_expand_specs(["env=dev,prod", "region=us,eu"])
+    assert variants == [
+        {"env": "dev", "region": "us"},
+        {"env": "dev", "region": "eu"},
+        {"env": "prod", "region": "us"},
+        {"env": "prod", "region": "eu"},
+    ]
+
+
+class _SpecErrorCase(t.NamedTuple):
+    """A malformed --expand spec and the phrase its error must mention."""
+
+    test_id: str
+    specs: list[str]
+    needle: str
+
+
+_SPEC_ERROR_CASES: tuple[_SpecErrorCase, ...] = (
+    _SpecErrorCase(
+        test_id="no_equals", specs=["noequals"], needle="expected KEY=V1,V2"
+    ),
+    _SpecErrorCase(test_id="empty_key", specs=["=v1,v2"], needle="expected KEY=V1,V2"),
+    _SpecErrorCase(test_id="no_values", specs=["env="], needle="no values"),
+    _SpecErrorCase(test_id="blank_values", specs=["env=,,"], needle="no values"),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    _SPEC_ERROR_CASES,
+    ids=[c.test_id for c in _SPEC_ERROR_CASES],
+)
+def test_parse_expand_specs_rejects_malformed(case: _SpecErrorCase) -> None:
+    """Malformed --expand specs raise ValueError with a helpful message."""
+    with pytest.raises(ValueError, match=case.needle):
+        _parse_expand_specs(case.specs)
+
+
+def test_expand_matrix_builds_sessions(
+    server: Server,
+    tmp_path: pathlib.Path,
+) -> None:
+    """``--expand`` renders one session per matrix point, substituting $vars."""
+    assert server.socket_name is not None
+    cfg = tmp_path / "svc.yaml"
+    cfg.write_text(
+        "session_name: exp-$env-$region\n"
+        "windows:\n"
+        "  - window_name: $env\n"
+        "    panes: [echo $env $region]\n",
+        encoding="utf-8",
+    )
+    names = ["exp-dev-us", "exp-dev-eu", "exp-prod-us", "exp-prod-eu"]
+    try:
+        with contextlib.suppress(SystemExit):
+            # No --parallel: --expand implies the folded set build.
+            cli.cli(
+                [
+                    "load",
+                    str(cfg),
+                    "--expand",
+                    "env=dev,prod",
+                    "--expand",
+                    "region=us,eu",
+                    "-d",
+                    "-L",
+                    server.socket_name,
+                ],
+            )
+        built = sorted(
+            name
+            for s in server.sessions
+            if (name := s.name) is not None and name.startswith("exp-")
+        )
+        assert built == sorted(names)
+        dev_us = server.sessions.get(session_name="exp-dev-us", default=None)
+        assert dev_us is not None
+        # Substitution reaches nested fields, not just the session name.
+        assert dev_us.windows[0].window_name == "dev"
+    finally:
+        _kill(server, *names)
+
+
+def test_expand_rejects_multiple_files(
+    server: Server,
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--expand`` expands a single base file, so extra files are rejected."""
+    assert server.socket_name is not None
+    cfg = tmp_path / "a.yaml"
+    _write_workspace(cfg, "exp-multi-$env", ["echo a"])
+    with contextlib.suppress(SystemExit):
+        cli.cli(
+            [
+                "load",
+                str(cfg),
+                str(cfg),
+                "--expand",
+                "env=dev",
+                "-d",
+                "-L",
+                server.socket_name,
+            ],
+        )
+    out = capsys.readouterr().out
+    assert "exactly one workspace file" in out

--- a/tests/cli/test_load_parallel.py
+++ b/tests/cli/test_load_parallel.py
@@ -1,0 +1,210 @@
+"""Tests for ``tmuxp load --parallel`` (engine-ops workspace set)."""
+
+from __future__ import annotations
+
+import contextlib
+import typing as t
+
+import pytest
+
+from tmuxp import cli
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+    from libtmux.server import Server
+
+
+def _kill(server: Server, *session_names: str) -> None:
+    """Kill each named session if present, leaving the server clean."""
+    for name in session_names:
+        with contextlib.suppress(Exception):
+            sess = server.sessions.get(session_name=name, default=None)
+            if sess is not None:
+                sess.kill()
+
+
+def _write_workspace(
+    path: pathlib.Path,
+    session_name: str,
+    panes: list[str],
+) -> None:
+    """Write a minimal single-window workspace file with *panes*."""
+    pane_list = ", ".join(panes)
+    path.write_text(
+        f"session_name: {session_name}\nwindows:\n  - panes: [{pane_list}]\n",
+        encoding="utf-8",
+    )
+
+
+class _ParallelCase(t.NamedTuple):
+    """A batch of workspaces and the pane count each should build."""
+
+    test_id: str
+    # (session_name, pane commands) per workspace file, in declaration order.
+    sessions: tuple[tuple[str, list[str]], ...]
+
+
+_PARALLEL_CASES: tuple[_ParallelCase, ...] = (
+    _ParallelCase(
+        test_id="single_file_set",
+        sessions=(("ppar-solo", ["echo a", "echo b"]),),
+    ),
+    _ParallelCase(
+        test_id="two_file_set",
+        sessions=(
+            ("ppar-a", ["echo a1", "echo a2"]),
+            ("ppar-b", ["echo b1"]),
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    _PARALLEL_CASES,
+    ids=[c.test_id for c in _PARALLEL_CASES],
+)
+def test_parallel_builds_all_sessions(
+    case: _ParallelCase,
+    server: Server,
+    tmp_path: pathlib.Path,
+) -> None:
+    """``--parallel`` builds every file's session as one folded set."""
+    assert server.socket_name is not None
+    files: list[str] = []
+    names: list[str] = []
+    for idx, (session_name, panes) in enumerate(case.sessions):
+        cfg = tmp_path / f"ws{idx}.yaml"
+        _write_workspace(cfg, session_name, panes)
+        files.append(str(cfg))
+        names.append(session_name)
+    try:
+        with contextlib.suppress(SystemExit):
+            cli.cli(
+                ["load", *files, "--parallel", "-d", "-L", server.socket_name],
+            )
+        for session_name, panes in case.sessions:
+            built = server.sessions.get(session_name=session_name, default=None)
+            assert built is not None
+            assert len(built.windows[0].panes) == len(panes)
+    finally:
+        _kill(server, *names)
+
+
+def test_parallel_dry_run_does_not_build(
+    server: Server,
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--dry-run`` prints the compiled plan and touches no tmux server."""
+    assert server.socket_name is not None
+    cfg = tmp_path / "ws.yaml"
+    _write_workspace(cfg, "ppar-dry", ["echo a", "echo b"])
+    with contextlib.suppress(SystemExit):
+        cli.cli(
+            ["load", str(cfg), "--parallel", "--dry-run", "-L", server.socket_name],
+        )
+    out = capsys.readouterr().out
+    assert "[Dry run]" in out
+    assert "new-session" in out
+    assert server.sessions.get(session_name="ppar-dry", default=None) is None
+
+
+def test_parallel_rejects_duplicate_names(
+    server: Server,
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Two workspaces with the same session name are unbuildable."""
+    assert server.socket_name is not None
+    cfg = tmp_path / "ws.yaml"
+    _write_workspace(cfg, "ppar-dup", ["echo a"])
+    try:
+        with contextlib.suppress(SystemExit):
+            cli.cli(
+                [
+                    "load",
+                    str(cfg),
+                    str(cfg),
+                    "--parallel",
+                    "-d",
+                    "-L",
+                    server.socket_name,
+                ],
+            )
+        out = capsys.readouterr().out
+        assert "duplicate sessions" in out
+        assert server.sessions.get(session_name="ppar-dup", default=None) is None
+    finally:
+        _kill(server, "ppar-dup")
+
+
+@pytest.mark.parametrize("flag", ["--dry-run", "--no-fold"])
+def test_dry_run_and_no_fold_require_parallel(
+    flag: str,
+    server: Server,
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--dry-run``/``--no-fold`` without ``--parallel`` fail instead of building."""
+    assert server.socket_name is not None
+    cfg = tmp_path / "ws.yaml"
+    _write_workspace(cfg, "ppar-guard", ["echo a"])
+    try:
+        with contextlib.suppress(SystemExit):
+            cli.cli(["load", str(cfg), flag, "-d", "-L", server.socket_name])
+        out = capsys.readouterr().out
+        assert "require --parallel" in out
+        assert server.sessions.get(session_name="ppar-guard", default=None) is None
+    finally:
+        _kill(server, "ppar-guard")
+
+
+class _RejectCase(t.NamedTuple):
+    """An incompatible flag and the phrase its rejection must mention."""
+
+    test_id: str
+    extra_args: list[str]
+    needle: str
+
+
+_REJECT_CASES: tuple[_RejectCase, ...] = (
+    _RejectCase(test_id="append", extra_args=["-a"], needle="--append"),
+    _RejectCase(test_id="new_session_name", extra_args=["-s", "renamed"], needle="-s"),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    _REJECT_CASES,
+    ids=[c.test_id for c in _REJECT_CASES],
+)
+def test_parallel_rejects_incompatible_flags(
+    case: _RejectCase,
+    server: Server,
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--parallel`` refuses single-session flags before touching tmux."""
+    assert server.socket_name is not None
+    cfg = tmp_path / "ws.yaml"
+    _write_workspace(cfg, "ppar-reject", ["echo a"])
+    try:
+        with contextlib.suppress(SystemExit):
+            cli.cli(
+                [
+                    "load",
+                    str(cfg),
+                    "--parallel",
+                    "-d",
+                    "-L",
+                    server.socket_name,
+                    *case.extra_args,
+                ],
+            )
+        out = capsys.readouterr().out
+        assert case.needle in out
+        assert server.sessions.get(session_name="ppar-reject", default=None) is None
+    finally:
+        _kill(server, "ppar-reject")

--- a/tests/cli/test_load_parallel_plugins.py
+++ b/tests/cli/test_load_parallel_plugins.py
@@ -1,0 +1,203 @@
+"""Plugin-hook behavior on the engine-ops set-build path (--parallel/--expand)."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import typing as t
+
+import pytest
+
+from tmuxp import cli
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+    from libtmux.server import Server
+
+_BS = "tmuxp_test_plugin_bs.plugin.PluginBeforeScript"
+_BWB = "tmuxp_test_plugin_bwb.plugin.PluginBeforeWorkspaceBuilder"
+_OWC = "tmuxp_test_plugin_owc.plugin.PluginOnWindowCreate"
+_AWF = "tmuxp_test_plugin_awf.plugin.PluginAfterWindowFinished"
+
+
+def _kill(server: Server, *session_names: str) -> None:
+    """Kill each named session if present, leaving the server clean."""
+    for name in session_names:
+        with contextlib.suppress(Exception):
+            sess = server.sessions.get(session_name=name, default=None)
+            if sess is not None:
+                sess.kill()
+
+
+def _skip_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Return the mid-build-hook skip warnings captured so far."""
+    return [r for r in caplog.records if getattr(r, "skipped_hooks", None)]
+
+
+class _HookCase(t.NamedTuple):
+    """A plugin, the set flag, and the hook behavior it should exhibit."""
+
+    test_id: str
+    dotted: str
+    flag_args: list[str]
+    declared_name: str
+    expect_session: str
+    warn_hook: str | None
+    cleanup: tuple[str, ...]
+
+
+_HOOK_CASES: tuple[_HookCase, ...] = (
+    _HookCase(
+        test_id="before_script_parallel_runs",
+        dotted=_BS,
+        flag_args=["--parallel"],
+        declared_name="plug-bs",
+        expect_session="plugin_test_bs",  # renamed by before_script
+        warn_hook=None,
+        cleanup=("plug-bs", "plugin_test_bs"),
+    ),
+    _HookCase(
+        test_id="before_script_expand_runs",
+        dotted=_BS,
+        flag_args=["--expand", "n=solo"],
+        declared_name="plug-$n",
+        expect_session="plugin_test_bs",
+        warn_hook=None,
+        cleanup=("plug-solo", "plugin_test_bs"),
+    ),
+    _HookCase(
+        test_id="before_workspace_builder_warns",
+        dotted=_BWB,
+        flag_args=["--parallel"],
+        declared_name="plug-bwb",
+        expect_session="plug-bwb",  # NOT renamed: mid-build hook skipped
+        warn_hook="before_workspace_builder",
+        cleanup=("plug-bwb",),
+    ),
+    _HookCase(
+        test_id="on_window_create_warns",
+        dotted=_OWC,
+        flag_args=["--parallel"],
+        declared_name="plug-owc",
+        expect_session="plug-owc",
+        warn_hook="on_window_create",
+        cleanup=("plug-owc",),
+    ),
+    _HookCase(
+        test_id="after_window_finished_warns",
+        dotted=_AWF,
+        flag_args=["--parallel"],
+        declared_name="plug-awf",
+        expect_session="plug-awf",
+        warn_hook="after_window_finished",
+        cleanup=("plug-awf",),
+    ),
+)
+
+
+@pytest.mark.usefixtures("monkeypatch_plugin_test_packages")
+@pytest.mark.parametrize("case", _HOOK_CASES, ids=[c.test_id for c in _HOOK_CASES])
+def test_set_path_plugin_hooks(
+    case: _HookCase,
+    server: Server,
+    tmp_path: pathlib.Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Post-build before_script runs; mid-build hooks warn and skip."""
+    assert server.socket_name is not None
+    cfg = tmp_path / "ws.yaml"
+    cfg.write_text(
+        f"session_name: {case.declared_name}\n"
+        f"plugins:\n- '{case.dotted}'\n"
+        "windows:\n- panes: [echo a]\n",
+        encoding="utf-8",
+    )
+    try:
+        with (
+            caplog.at_level(logging.WARNING, logger="tmuxp.cli.load"),
+            contextlib.suppress(SystemExit),
+        ):
+            cli.cli(["load", str(cfg), *case.flag_args, "-d", "-L", server.socket_name])
+        assert server.sessions.get(session_name=case.expect_session, default=None)
+        warns = _skip_warnings(caplog)
+        if case.warn_hook is None:
+            assert warns == []
+        else:
+            assert any(case.warn_hook in getattr(r, "skipped_hooks", "") for r in warns)
+            assert all(getattr(r, "plugin", None) for r in warns)
+    finally:
+        _kill(server, *case.cleanup)
+
+
+def test_set_path_before_script_raise_is_lenient(
+    server: Server,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A before_script that raises is logged and skipped, not fatal to the set."""
+    assert server.socket_name is not None
+    (tmp_path / "raising_plugin.py").write_text(
+        "from __future__ import annotations\n\n"
+        "from tmuxp.plugin import TmuxpPlugin\n\n\n"
+        "class Boom(TmuxpPlugin):\n"
+        "    def __init__(self) -> None:\n"
+        "        pass\n\n"
+        "    def before_script(self, session) -> None:\n"
+        "        raise RuntimeError('boom')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    cfg = tmp_path / "ws.yaml"
+    cfg.write_text(
+        "session_name: boom-a\n"
+        "plugins:\n- 'raising_plugin.Boom'\n"
+        "windows:\n- panes: [echo a]\n",
+        encoding="utf-8",
+    )
+    try:
+        with (
+            caplog.at_level(logging.WARNING, logger="tmuxp.cli.load"),
+            contextlib.suppress(SystemExit),
+        ):
+            cli.cli(["load", str(cfg), "--parallel", "-d", "-L", server.socket_name])
+        # The build survived the raising hook.
+        assert server.sessions.get(session_name="boom-a", default=None)
+        assert any("before_script failed" in r.getMessage() for r in caplog.records)
+    finally:
+        _kill(server, "boom-a")
+
+
+def test_set_path_no_plugins_skips_loading(
+    server: Server,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plugin-free set build never calls load_plugins."""
+    assert server.socket_name is not None
+    calls: list[dict[str, t.Any]] = []
+    from tmuxp.cli import load as load_module
+
+    real = load_module.load_plugins
+
+    def _spy(
+        session_config: dict[str, t.Any],
+        colors: t.Any = None,
+    ) -> list[t.Any]:
+        calls.append(session_config)
+        return real(session_config, colors)
+
+    monkeypatch.setattr(load_module, "load_plugins", _spy)
+    cfg = tmp_path / "ws.yaml"
+    cfg.write_text(
+        "session_name: noplug-a\nwindows:\n- panes: [echo a]\n",
+        encoding="utf-8",
+    )
+    try:
+        with contextlib.suppress(SystemExit):
+            cli.cli(["load", str(cfg), "--parallel", "-d", "-L", server.socket_name])
+        assert server.sessions.get(session_name="noplug-a", default=None)
+        assert calls == []
+    finally:
+        _kill(server, "noplug-a")

--- a/tests/workspace/test_builder_engine_ops.py
+++ b/tests/workspace/test_builder_engine_ops.py
@@ -76,6 +76,42 @@ def test_engine_ops_build_shape(case: _BuildCase, session: Session) -> None:
         _kill(server, case.config["session_name"])
 
 
+class _EngineCase(t.NamedTuple):
+    """An engine_ops_engine choice for the builder."""
+
+    test_id: str
+    engine_ops_engine: str
+
+
+_ENGINE_CASES: tuple[_EngineCase, ...] = (
+    _EngineCase(test_id="subprocess", engine_ops_engine="subprocess"),
+    _EngineCase(test_id="control_mode", engine_ops_engine="control_mode"),
+)
+
+
+@pytest.mark.parametrize("case", _ENGINE_CASES, ids=[c.test_id for c in _ENGINE_CASES])
+def test_engine_ops_engine_choice_builds(case: _EngineCase, session: Session) -> None:
+    """The engine_ops_engine key selects the async engine and still builds."""
+    server = session.server
+    session_name = f"eo-eng-{case.test_id}"
+    config = {
+        "session_name": session_name,
+        "engine_ops_engine": case.engine_ops_engine,
+        "windows": [
+            {"window_name": "w0", "panes": ["echo a", "echo b"]},
+            {"window_name": "w1", "panes": ["echo c"]},
+        ],
+    }
+    builder = EngineOpsWorkspaceBuilder(session_config=config, server=server)
+    try:
+        builder.build()
+        built = builder.session
+        assert built.name == session_name
+        assert [len(w.panes) for w in built.windows] == [2, 1]
+    finally:
+        _kill(server, session_name)
+
+
 def test_engine_ops_satisfies_protocol(session: Session) -> None:
     """The builder is a conforming WorkspaceBuilderProtocol instance."""
     builder = EngineOpsWorkspaceBuilder(

--- a/tests/workspace/test_builder_engine_ops.py
+++ b/tests/workspace/test_builder_engine_ops.py
@@ -1,0 +1,129 @@
+"""Tests for the engine-ops (async, folding) workspace builder."""
+
+from __future__ import annotations
+
+import contextlib
+import typing as t
+
+import pytest
+
+from tmuxp import exc
+from tmuxp.workspace.builder.engine_ops import EngineOpsWorkspaceBuilder
+from tmuxp.workspace.builder.protocol import WorkspaceBuilderProtocol
+from tmuxp.workspace.builder.registry import resolve_builder_class
+
+if t.TYPE_CHECKING:
+    from libtmux.server import Server
+    from libtmux.session import Session
+
+
+def _kill(server: Server, session_name: str) -> None:
+    """Kill *session_name* if present, so a build leaves the server clean."""
+    with contextlib.suppress(Exception):
+        sess = server.sessions.get(session_name=session_name)
+        if sess is not None:
+            sess.kill()
+
+
+class _BuildCase(t.NamedTuple):
+    """A workspace config and the window/pane shape it should build."""
+
+    test_id: str
+    config: dict[str, t.Any]
+    windows: int
+    panes_per_window: list[int]
+
+
+_BUILD_CASES: tuple[_BuildCase, ...] = (
+    _BuildCase(
+        test_id="single_window_two_panes",
+        config={
+            "session_name": "eo-two",
+            "windows": [{"window_name": "editor", "panes": ["echo a", "echo b"]}],
+        },
+        windows=1,
+        panes_per_window=[2],
+    ),
+    _BuildCase(
+        test_id="two_windows_mixed_panes",
+        config={
+            "session_name": "eo-mixed",
+            "windows": [
+                {"window_name": "editor", "panes": ["echo a", "echo b", "echo c"]},
+                {"window_name": "logs", "panes": ["echo tail"]},
+            ],
+        },
+        windows=2,
+        panes_per_window=[3, 1],
+    ),
+)
+
+
+@pytest.mark.parametrize("case", _BUILD_CASES, ids=[c.test_id for c in _BUILD_CASES])
+def test_engine_ops_build_shape(case: _BuildCase, session: Session) -> None:
+    """The folding async build creates the declared windows and panes."""
+    server = session.server
+    builder = EngineOpsWorkspaceBuilder(session_config=case.config, server=server)
+    try:
+        builder.build()
+        built = builder.session
+        assert built.name == case.config["session_name"]
+        assert len(built.windows) == case.windows
+        assert [len(w.panes) for w in built.windows] == case.panes_per_window
+    finally:
+        _kill(server, case.config["session_name"])
+
+
+def test_engine_ops_satisfies_protocol(session: Session) -> None:
+    """The builder is a conforming WorkspaceBuilderProtocol instance."""
+    builder = EngineOpsWorkspaceBuilder(
+        session_config={"session_name": "eo-proto", "windows": [{"panes": ["echo x"]}]},
+        server=session.server,
+    )
+    assert isinstance(builder, WorkspaceBuilderProtocol)
+
+
+def test_engine_ops_resolves_via_entry_point() -> None:
+    """The ``workspace_builder: engine-ops`` config selects this builder."""
+    resolved = resolve_builder_class({"workspace_builder": "engine-ops"})
+    assert resolved is EngineOpsWorkspaceBuilder
+
+
+def test_engine_ops_emits_build_events(session: Session) -> None:
+    """Structural events are forwarded, ending with workspace_built."""
+    events: list[dict[str, t.Any]] = []
+    builder = EngineOpsWorkspaceBuilder(
+        session_config={
+            "session_name": "eo-events",
+            "windows": [{"window_name": "w", "panes": ["echo a", "echo b"]}],
+        },
+        server=session.server,
+        on_build_event=events.append,
+    )
+    try:
+        builder.build()
+        names = [e["event"] for e in events]
+        assert names[0] == "session_created"
+        assert names[-1] == "workspace_built"
+        assert "pane_created" in names
+    finally:
+        _kill(session.server, "eo-events")
+
+
+def test_engine_ops_append_unsupported(session: Session) -> None:
+    """Append is not expressible in the IR; the builder refuses it."""
+    builder = EngineOpsWorkspaceBuilder(
+        session_config={
+            "session_name": "eo-append",
+            "windows": [{"panes": ["echo x"]}],
+        },
+        server=session.server,
+    )
+    with pytest.raises(NotImplementedError, match="append"):
+        builder.build(append=True)
+
+
+def test_engine_ops_empty_config_raises(session: Session) -> None:
+    """An empty config fails fast, matching the classic builder."""
+    with pytest.raises(exc.EmptyWorkspaceException):
+        EngineOpsWorkspaceBuilder(session_config={}, server=session.server)

--- a/tests/workspace/test_builder_engine_ops.py
+++ b/tests/workspace/test_builder_engine_ops.py
@@ -13,6 +13,8 @@ from tmuxp.workspace.builder.protocol import WorkspaceBuilderProtocol
 from tmuxp.workspace.builder.registry import resolve_builder_class
 
 if t.TYPE_CHECKING:
+    import pathlib
+
     from libtmux.server import Server
     from libtmux.session import Session
 
@@ -127,3 +129,34 @@ def test_engine_ops_empty_config_raises(session: Session) -> None:
     """An empty config fails fast, matching the classic builder."""
     with pytest.raises(exc.EmptyWorkspaceException):
         EngineOpsWorkspaceBuilder(session_config={}, server=session.server)
+
+
+def test_engine_ops_cli_flag_builds(server: Server, tmp_path: pathlib.Path) -> None:
+    """`tmuxp load --engine-ops` routes a config through the engine-ops builder."""
+    from tmuxp import cli
+
+    socket_name = server.socket_name
+    assert socket_name is not None
+    config = tmp_path / "ws.yaml"
+    config.write_text(
+        "session_name: eo-cli\nwindows:\n  - panes: [echo a, echo b]\n",
+    )
+    try:
+        with contextlib.suppress(SystemExit):
+            cli.cli(
+                [
+                    "load",
+                    str(config),
+                    "--engine-ops",
+                    "-d",
+                    "-L",
+                    socket_name,
+                    "-y",
+                ],
+            )
+        assert server.has_session("eo-cli")
+        built = server.sessions.get(session_name="eo-cli")
+        assert built is not None
+        assert len(built.windows[0].panes) == 2
+    finally:
+        _kill(server, "eo-cli")

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.61.0"
-source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#4393b02a0935d0f5cac8b85f6e2a9c180e82169b" }
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#f52b2d3f616d71de1c4af7ac9cba9e92e80d8459" }
 
 [[package]]
 name = "linkify-it-py"

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.61.0"
-source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#aa6d822d5eaff876c43062c6d6e6405410cda8bf" }
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#1fe8fc67650b57c516e6015a21cef0d18761b2e9" }
 
 [[package]]
 name = "linkify-it-py"

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.61.0"
-source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#1fe8fc67650b57c516e6015a21cef0d18761b2e9" }
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#e88e87b6d6ef22ac08eb4025de78e5f9ec205928" }
 
 [[package]]
 name = "linkify-it-py"

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.61.0"
-source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#be88f08de93e84806602c82c64c5195125bd566b" }
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#aa6d822d5eaff876c43062c6d6e6405410cda8bf" }
 
 [[package]]
 name = "linkify-it-py"

--- a/uv.lock
+++ b/uv.lock
@@ -610,11 +610,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.61.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/c2/6abbac4420c35b3f1140c72607117236b160173f74fd86941f99b28375d5/libtmux-0.61.0.tar.gz", hash = "sha256:2d6081081a629b9236a36a64f874667533811d2ce5a1b0caa9c821f4d9d2e618", size = 546122, upload-time = "2026-07-04T12:57:36.401Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/14/934d0d9076d1d46fcc71f3397daea7921363781674337084b15d1bbcbf84/libtmux-0.61.0-py3-none-any.whl", hash = "sha256:b9315db6600757f840a8f16438725103e579aaa4be3c32728c105f2c284330df", size = 118059, upload-time = "2026-07-04T12:57:34.598Z" },
-]
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#d361a2b15bb9f27ab1d04b25f7a52aeea4843c8b" }
 
 [[package]]
 name = "linkify-it-py"
@@ -1703,7 +1699,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "libtmux", specifier = "~=0.61.0" },
+    { name = "libtmux", git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.61.0"
-source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#f52b2d3f616d71de1c4af7ac9cba9e92e80d8459" }
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#be88f08de93e84806602c82c64c5195125bd566b" }
 
 [[package]]
 name = "linkify-it-py"

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.61.0"
-source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#e88e87b6d6ef22ac08eb4025de78e5f9ec205928" }
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#22557d9815bb332bfa0ef96fc1d7050f953aeba8" }
 
 [[package]]
 name = "linkify-it-py"

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 [[package]]
 name = "libtmux"
 version = "0.61.0"
-source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#d361a2b15bb9f27ab1d04b25f7a52aeea4843c8b" }
+source = { git = "https://github.com/tmux-python/libtmux.git?branch=engine-ops#4393b02a0935d0f5cac8b85f6e2a9c180e82169b" }
 
 [[package]]
 name = "linkify-it-py"


### PR DESCRIPTION
Adds an opt-in async workspace builder backed by libtmux's experimental engine-ops stack, plus CLI switches for single-session, parallel, and matrix loads.

## What's here

- **`EngineOpsWorkspaceBuilder`** (`workspace/builder/engine_ops.py`): a `WorkspaceBuilderProtocol` that lowers an expanded workspace dict to libtmux's declarative `Workspace` IR and `abuild`s it asynchronously. The build *folds*: a multi-pane window's commands collapse into a handful of `;`-chained dispatches instead of one `send-keys` per line, so a session renders in a few round-trips rather than dozens. Registered as the `engine-ops` entry point.
- **`workspace_builder: engine-ops`** config key selects the builder.
- **`tmuxp load --engine-ops`** selects it for a single load without editing the workspace file; the load spinner keeps working via a structural-event bridge.
- **`tmuxp load --engine-ops-engine {subprocess,control_mode}`** picks the async engine the fold runs on (default `subprocess`). `subprocess` forks a `tmux` per dispatch; `control_mode` drives the whole fold over one persistent `tmux -C` control-mode client, trading per-call process spawns for a single long-lived connection. Applies to `--engine-ops`, `--parallel`, and `--expand` alike. (imsg has no async engine, so it isn't offered here.)
- **`tmuxp load --parallel`** builds every WORKSPACE_FILE as one `WorkspaceSet`: all sessions compile into a single rebased, folded plan sharing one preflight, instead of one detached load per file. `--dry-run` prints the compiled tmux plan without touching the server; `--no-fold` dispatches one command per operation for debugging. `-a/--append` and `-s` are rejected (they describe single-session semantics).
- **`tmuxp load --expand KEY=V1,V2`** expands one parameterized file into a session per value, substituting `$KEY` placeholders (e.g. `session_name: app-$env`). Repeat `--expand` for a matrix (Cartesian product). Implies the folded set build.

## Plugin support on the set path

`--parallel`/`--expand` run the post-build `before_script` plugin hook on each built session (loaded before the fold so the version pre-flight still gates; run in the file's import sandbox; a raising hook is logged, not fatal to the other sessions). Mid-build hooks (`before_workspace_builder`, `on_window_create`, `after_window_finished`) can't fire without unfolding the plan, so a plugin that overrides one is **skipped with a warning**; `reattach` isn't fired on fresh builds (as on any fresh sequential load). Load a workspace on its own for the full hook sequence. See `docs/topics/plugins.md`.

## Notes

- Session collisions surface as `FileExistsError` (`on_exists='error'`); duplicate session names in a set are rejected up front.
- Progress streaming through `abuild(on_event=...)` is intentionally **not** wired here: the plugin hooks run after `asyncio.run` returns and never touch the event stream. (A future streaming PR should route `on_event` through a bounded non-blocking pump — libtmux's `sets.py` currently `await`s the sink inline, which would head-of-line-block the fold.)

## Try it via uvx / uv tool

This branch pins `libtmux` to its unreleased `engine-ops` branch via `[tool.uv.sources]`, and a recent `uv` (tested with 0.11.25) honors that pin when installing from git — so no extra flags are needed. Do **not** add `--with git+…libtmux…`: the pin already supplies it, and a second URL fails with a "conflicting URLs" error. You'll also need `tmux` on your PATH. These commands attach to the new session; add `-d` (`--detach`) to build it in the background instead.

Run it once, ephemerally, with `uvx`:

```
uvx --from git+https://github.com/tmux-python/tmuxp.git@engine-ops tmuxp load --engine-ops ./workspace.yaml
```

Pick the engine the fold runs on. The default is `subprocess` (a `tmux` fork per dispatch); pass `--engine-ops-engine control_mode` to drive the whole fold over one persistent `tmux -C` client instead:

```
uvx --from git+https://github.com/tmux-python/tmuxp.git@engine-ops tmuxp load --engine-ops --engine-ops-engine control_mode ./workspace.yaml
```

Build several workspaces as one folded set:

```
uvx --from git+https://github.com/tmux-python/tmuxp.git@engine-ops tmuxp load --parallel a.yaml b.yaml
```

Or expand one parameterized file into a matrix of sessions:

```
uvx --from git+https://github.com/tmux-python/tmuxp.git@engine-ops tmuxp load --expand env=dev,prod ./app.yaml
```

The `--engine-ops-engine` switch works on the set path too:

```
uvx --from git+https://github.com/tmux-python/tmuxp.git@engine-ops tmuxp load --expand env=dev,prod --engine-ops-engine control_mode ./app.yaml
```

Install it persistently as `tmuxp` on your PATH:

```
uv tool install --from git+https://github.com/tmux-python/tmuxp.git@engine-ops tmuxp
```

Then load any workspace through the folding builder:

```
tmuxp load --engine-ops ./workspace.yaml
```

## Dependency

Pins `libtmux` to the `engine-ops` branch via `[tool.uv.sources]` — the engine-ops workspace API is unreleased (`libtmux.experimental`). **Draft** until that lands.
