### PR TITLE
docs: Attributes sections for NamedTuple and TypedDict fields

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -69,6 +69,12 @@ Workflow actions moved to their current major releases: `actions/checkout` v7,
 v6. Workflow behavior is unchanged, though setup-uv no longer prunes the uv
 cache, so the first run after this repopulates it.
 
+#### Class fields describe themselves in the API reference (#1080)
+
+The workspace, plugin, and CLI types now say what each field holds. They
+previously reached the rendered API reference as "Alias for field number 0"
+or as a bare name carrying only its type.
+
 ## tmuxp 1.74.0 (2026-07-04)
 
 tmuxp 1.74.0 pairs a libtmux upgrade with a documentation overhaul. It bumps libtmux to 0.61.0 — hardening tmux 3.7 patch-line support — and teaches `tmuxp debug-info` to report the exact tmux patch release (`3.7a`/`3.7b`) instead of the numeric-normalized version. The docs also gain theme-aware inline diagrams and a concept-first rewrite that leads with what each feature is before its configuration.

--- a/src/tmuxp/_internal/types.py
+++ b/src/tmuxp/_internal/types.py
@@ -28,6 +28,40 @@ if t.TYPE_CHECKING:
 
 
 class PluginConfigSchema(TypedDict):
+    """Keyword arguments accepted by :class:`tmuxp.plugin.TmuxpPlugin`.
+
+    Every key is optional. :func:`tmuxp.plugin.setup_plugin_config` fills each
+    omitted key from ``tmuxp.plugin.DEFAULT_CONFIG`` before the plugin runs its
+    version checks.
+
+    Attributes
+    ----------
+    plugin_name : NotRequired[str]
+        Name of the plugin, used to identify it in version incompatibility
+        messages.
+    tmux_min_version : NotRequired[str]
+        Oldest tmux version the plugin supports.
+    tmux_max_version : NotRequired[str]
+        Newest tmux version the plugin supports.
+    tmux_version_incompatible : NotRequired[list[str]]
+        Individual tmux versions the plugin rejects even though they fall
+        inside the min / max range.
+    libtmux_min_version : NotRequired[str]
+        Oldest libtmux version the plugin supports.
+    libtmux_max_version : NotRequired[str]
+        Newest libtmux version the plugin supports.
+    libtmux_version_incompatible : NotRequired[list[str]]
+        Individual libtmux versions the plugin rejects even though they fall
+        inside the min / max range.
+    tmuxp_min_version : NotRequired[str]
+        Oldest tmuxp version the plugin supports.
+    tmuxp_max_version : NotRequired[str]
+        Newest tmuxp version the plugin supports.
+    tmuxp_version_incompatible : NotRequired[list[str]]
+        Individual tmuxp versions the plugin rejects even though they fall
+        inside the min / max range.
+    """
+
     plugin_name: NotRequired[str]
     tmux_min_version: NotRequired[str]
     tmux_max_version: NotRequired[str]

--- a/src/tmuxp/cli/_formatter.py
+++ b/src/tmuxp/cli/_formatter.py
@@ -251,6 +251,27 @@ class TmuxpHelpFormatter(argparse.RawDescriptionHelpFormatter):
 class HelpTheme(t.NamedTuple):
     """Theme colors for help output.
 
+    Each field is the ANSI escape prefix written before a token; ``reset``
+    closes it. :meth:`from_colors` sets every field to ``""`` when color is
+    disabled, so the same formatting code emits plain text.
+
+    Attributes
+    ----------
+    prog : str
+        Escape prefix for the program name leading an example command.
+    action : str
+        Escape prefix for the subcommand following the program name.
+    long_option : str
+        Escape prefix for ``--`` options.
+    short_option : str
+        Escape prefix for single-dash options.
+    label : str
+        Escape prefix for the value that follows an option expecting one.
+    heading : str
+        Escape prefix for example section headings such as ``Examples:``.
+    reset : str
+        Escape sequence that ends styling, ``""`` when color is disabled.
+
     Examples
     --------
     >>> from tmuxp.cli._formatter import HelpTheme

--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -93,7 +93,19 @@ if t.TYPE_CHECKING:
     CLIColorModeLiteral: TypeAlias = t.Literal["auto", "always", "never"]
 
     class OptionOverrides(TypedDict):
-        """Optional argument overrides for tmuxp load."""
+        """Optional argument overrides for tmuxp load.
+
+        Per-workspace-file adjustments layered over the command line options
+        when a single ``tmuxp load`` invocation builds more than one workspace.
+
+        Attributes
+        ----------
+        detached : NotRequired[bool]
+            Build the session in the background instead of attaching to it.
+        new_session_name : NotRequired[str | None]
+            Session name to use in place of the one in the workspace file.
+            ``None`` keeps the workspace file's own ``session_name``.
+        """
 
         detached: NotRequired[bool]
         new_session_name: NotRequired[str | None]

--- a/src/tmuxp/plugin.py
+++ b/src/tmuxp/plugin.py
@@ -43,7 +43,23 @@ if t.TYPE_CHECKING:
     from ._internal.types import PluginConfigSchema
 
     class VersionConstraints(TypedDict):
-        """Version constraints mapping for a tmuxp plugin."""
+        """Version constraints mapping for a tmuxp plugin.
+
+        Unpacked into :meth:`TmuxpPlugin._pass_version_check` to decide whether
+        one dependency satisfies the plugin's requirements.
+
+        Attributes
+        ----------
+        version : Version | str
+            Installed version of the dependency being checked.
+        vmin : str
+            Oldest version accepted. An empty string skips the lower bound.
+        vmax : str | None
+            Newest version accepted. ``None`` leaves the upper bound open.
+        incompatible : list[t.Any | str]
+            Versions rejected outright, even when inside the ``vmin`` /
+            ``vmax`` range.
+        """
 
         version: Version | str
         vmin: str
@@ -51,7 +67,20 @@ if t.TYPE_CHECKING:
         incompatible: list[t.Any | str]
 
     class TmuxpPluginVersionConstraints(TypedDict):
-        """Version constraints for a tmuxp plugin."""
+        """Version constraints for a tmuxp plugin.
+
+        Held on :attr:`TmuxpPlugin.version_constraints` and walked by
+        :meth:`TmuxpPlugin._version_check`, one entry per dependency.
+
+        Attributes
+        ----------
+        tmux : VersionConstraints
+            Bounds checked against the running tmux binary.
+        tmuxp : VersionConstraints
+            Bounds checked against the installed tmuxp.
+        libtmux : VersionConstraints
+            Bounds checked against the installed libtmux.
+        """
 
         tmux: VersionConstraints
         tmuxp: VersionConstraints
@@ -59,7 +88,42 @@ if t.TYPE_CHECKING:
 
 
 class Config(t.TypedDict):
-    """tmuxp plugin configuration mapping."""
+    """tmuxp plugin configuration mapping.
+
+    The fully populated form of the plugin keyword arguments: every key is
+    present once :func:`setup_plugin_config` has merged the caller's arguments
+    over ``DEFAULT_CONFIG``.
+
+    Attributes
+    ----------
+    plugin_name : str
+        Name of the plugin, used to identify it in version incompatibility
+        messages.
+    tmux_min_version : str
+        Oldest tmux version the plugin supports.
+    tmux_max_version : str | None
+        Newest tmux version the plugin supports. ``None`` leaves the upper
+        bound open.
+    tmux_version_incompatible : list[str] | None
+        Individual tmux versions the plugin rejects even though they fall
+        inside the min / max range. ``None`` means no such exclusions.
+    libtmux_min_version : str
+        Oldest libtmux version the plugin supports.
+    libtmux_max_version : str | None
+        Newest libtmux version the plugin supports. ``None`` leaves the upper
+        bound open.
+    libtmux_version_incompatible : list[str] | None
+        Individual libtmux versions the plugin rejects even though they fall
+        inside the min / max range. ``None`` means no such exclusions.
+    tmuxp_min_version : str
+        Oldest tmuxp version the plugin supports.
+    tmuxp_max_version : str | None
+        Newest tmuxp version the plugin supports. ``None`` leaves the upper
+        bound open.
+    tmuxp_version_incompatible : list[str] | None
+        Individual tmuxp versions the plugin rejects even though they fall
+        inside the min / max range. ``None`` means no such exclusions.
+    """
 
     plugin_name: str
     tmux_min_version: str

--- a/src/tmuxp/shell.py
+++ b/src/tmuxp/shell.py
@@ -32,7 +32,23 @@ if t.TYPE_CHECKING:
     ]
 
     class LaunchOptionalImports(TypedDict):
-        """tmuxp shell optional imports."""
+        """tmuxp shell optional imports.
+
+        The live tmux objects a caller can hand to the shell launchers. A key
+        left out is bound to ``None`` in the shell namespace by
+        :func:`get_launch_args`.
+
+        Attributes
+        ----------
+        server : NotRequired[Server]
+            Server the shell is attached to.
+        session : NotRequired[Session]
+            Session the shell is attached to.
+        window : NotRequired[Window]
+            Window the shell is attached to.
+        pane : NotRequired[Pane]
+            Pane the shell is attached to.
+        """
 
         server: NotRequired[Server]
         session: NotRequired[Session]
@@ -40,7 +56,32 @@ if t.TYPE_CHECKING:
         pane: NotRequired[Pane]
 
     class LaunchImports(t.TypedDict):
-        """tmuxp shell launch import mapping."""
+        """tmuxp shell launch import mapping.
+
+        The namespace pre-populated in the interactive shell: the libtmux
+        classes plus whichever live tmux objects the caller supplied.
+
+        Attributes
+        ----------
+        libtmux : ModuleType
+            The :mod:`libtmux` module itself.
+        Server : type[Server]
+            The :class:`libtmux.Server` class, for constructing new servers.
+        Session : type[Session]
+            The :class:`libtmux.Session` class, for constructing new sessions.
+        Window : type[Window]
+            The :class:`libtmux.Window` class, for constructing new windows.
+        Pane : type[Pane]
+            The :class:`libtmux.Pane` class, for constructing new panes.
+        server : Server | None
+            Server the shell is attached to, ``None`` when not supplied.
+        session : Session | None
+            Session the shell is attached to, ``None`` when not supplied.
+        window : Window | None
+            Window the shell is attached to, ``None`` when not supplied.
+        pane : Pane | None
+            Pane the shell is attached to, ``None`` when not supplied.
+        """
 
         libtmux: ModuleType
         Server: type[Server]


### PR DESCRIPTION
Autodoc renders every field of a `NamedTuple` or `TypedDict` whether or not the docstring describes it, so the plugin config schema, the version constraint mappings, the shell launch imports, the `tmuxp load` overrides, and the help theme reached the API reference as bare keys — and the `NamedTuple` fields as "Alias for field number 0". Each of those classes now carries a NumPy-style `Attributes` section naming every field with its type and what it holds, including what an open upper bound, an absent exclusion list, or an omitted optional import means. Docstrings only: no code, signature, or field-order changes.

Gates run and passing: `just ruff-format`, `just ruff`, `uv run mypy .`, `just test`, `just build-docs`.

The docs build succeeds, with new duplicate-object warnings for the newly described fields of `PluginConfigSchema`, `HelpTheme`, and `tmuxp.plugin.Config` — the NumPy preprocessor emits `.. attribute::` for each field while autodoc also renders it. The same warnings already exist on master for the classes documented before this branch, and the fix belongs in gp-sphinx rather than in a `docs/conf.py` suppression here.

Closes #1079
