### PR TITLE
Fix CLI declarations that disagree with runtime behaviour

### DIFF
--- a/src/tmuxp/cli/__init__.py
+++ b/src/tmuxp/cli/__init__.py
@@ -282,16 +282,12 @@ class CLINamespace(argparse.Namespace):
     import_subparser_name : CLIImportSubparserName | None
         Source format chosen under ``tmuxp import``. Unset when ``import`` runs
         without one, so readers reach for it with :func:`getattr`.
-    version : bool
-        Declared for ``--version``/``-V``. argparse's version action prints and
-        exits on its own, so this is never assigned.
     """
 
     log_level: CLIVerbosity
     color: CLIColorMode
     subparser_name: CLISubparserName
     import_subparser_name: CLIImportSubparserName | None
-    version: bool
 
 
 ns = CLINamespace()

--- a/src/tmuxp/cli/freeze.py
+++ b/src/tmuxp/cli/freeze.py
@@ -69,7 +69,7 @@ class CLIFreezeNamespace(argparse.Namespace):
         Format the workspace is written in (``-f``/``--workspace-format``).
         ``None`` infers it from the destination file's extension and prompts
         when that fails.
-    save_to : str | None
+    save_to : pathlib.Path | None
         Destination file (``-o``/``--save-to``). ``None`` prompts for a path,
         defaulting to the session name inside the tmuxp workspace directory.
     answer_yes : bool | None
@@ -89,7 +89,7 @@ class CLIFreezeNamespace(argparse.Namespace):
     socket_name: str | None
     socket_path: str | None
     workspace_format: CLIOutputFormatLiteral | None
-    save_to: str | None
+    save_to: pathlib.Path | None
     answer_yes: bool | None
     quiet: bool | None
     force: bool | None
@@ -142,13 +142,13 @@ def create_freeze_subparser(
         "-q",
         dest="quiet",
         action="store_true",
-        help="don't prompt for confirmation",
+        help="suppress informational output (use --yes to skip prompts)",
     )
     parser.add_argument(
         "--force",
         dest="force",
         action="store_true",
-        help="overwrite the workspace file",
+        help="accept a prompted destination that already exists",
     )
 
     return parser
@@ -209,7 +209,7 @@ def command_freeze(
             )
         sys.exit()
 
-    dest = args.save_to
+    dest: str | None = str(args.save_to) if args.save_to else None
     while not dest:
         save_to = os.path.abspath(
             os.path.join(

--- a/src/tmuxp/cli/load.py
+++ b/src/tmuxp/cli/load.py
@@ -89,7 +89,7 @@ if t.TYPE_CHECKING:
 
     from tmuxp.types import StrPath
 
-    CLIColorsLiteral: TypeAlias = t.Literal[56, 88]
+    CLIColorsLiteral: TypeAlias = t.Literal[256, 88]
     CLIColorModeLiteral: TypeAlias = t.Literal["auto", "always", "never"]
 
     class OptionOverrides(TypedDict):

--- a/src/tmuxp/cli/shell.py
+++ b/src/tmuxp/cli/shell.py
@@ -39,7 +39,6 @@ if t.TYPE_CHECKING:
     from typing import TypeAlias
 
     CLIColorModeLiteral: TypeAlias = t.Literal["auto", "always", "never"]
-    CLIColorsLiteral: TypeAlias = t.Literal[56, 88]
     CLIShellLiteral: TypeAlias = t.Literal[
         "best",
         "pdb",
@@ -69,12 +68,6 @@ class CLIShellNamespace(argparse.Namespace):
     socket_path : str | None
         Pass-through for ``tmux -S``. When neither this nor ``socket_name`` is
         given and ``TMUX`` is set, the socket path is read from that variable.
-    colors : CLIColorsLiteral | None
-        Color count forced on tmux. The ``shell`` subparser defines no
-        ``-2``/``-8`` flags, so argparse never sets this.
-    log_file : str | None
-        Destination for the file log. The ``shell`` subparser defines no
-        ``--log-file`` flag, so argparse never sets this.
     window_name : str | None
         Window bound to the shell's ``window`` variable. Unset when the
         positional is omitted, which falls back to the window owning the pane
@@ -99,8 +92,6 @@ class CLIShellNamespace(argparse.Namespace):
     session_name: str
     socket_name: str | None
     socket_path: str | None
-    colors: CLIColorsLiteral | None
-    log_file: str | None
     window_name: str | None
     command: str | None
     shell: CLIShellLiteral | None

--- a/tests/cli/test_freeze.py
+++ b/tests/cli/test_freeze.py
@@ -147,3 +147,39 @@ def test_freeze_overwrite(
 
     yaml_config_path = tmp_path / "exists.yaml"
     assert yaml_config_path.exists()
+
+
+def _freeze_help(dest: str) -> str:
+    """Return the help text of the freeze flag storing into *dest*."""
+    import argparse
+
+    from tmuxp.cli.freeze import create_freeze_subparser
+
+    parser = create_freeze_subparser(argparse.ArgumentParser(prog="freeze"))
+    action = next(a for a in parser._actions if a.dest == dest)
+    assert action.help is not None
+    return action.help
+
+
+def test_freeze_save_to_parses_as_a_path() -> None:
+    """-o/--save-to stores a pathlib.Path, matching its declared type."""
+    import argparse
+    import pathlib
+
+    from tmuxp.cli.freeze import create_freeze_subparser
+
+    parser = create_freeze_subparser(argparse.ArgumentParser(prog="freeze"))
+    args = parser.parse_args(["-o", "out.yaml"])
+    assert isinstance(args.save_to, pathlib.Path)
+
+
+def test_freeze_quiet_help_describes_what_it_silences() -> None:
+    """--quiet advertises output suppression, not prompt suppression."""
+    help_text = _freeze_help("quiet")
+    assert "output" in help_text
+    assert "--yes" in help_text
+
+
+def test_freeze_force_help_scopes_itself_to_the_prompt() -> None:
+    """--force advertises the prompted destination it actually affects."""
+    assert "prompt" in _freeze_help("force")


### PR DESCRIPTION
## Summary

- **Fix** `--quiet` and `--force` help strings in `tmuxp freeze`, both of which described behaviour the flags do not have
- **Fix** `CLIFreezeNamespace.save_to`, typed `str | None` while `-o/--save-to` parses with `type=pathlib.Path`
- **Fix** `CLIColorsLiteral`, which admitted `56` (a value nothing produces) and excluded `256` (the value `-2` assigns)
- **Remove** three namespace annotations declared for flags that do not exist

Each was found while documenting these classes: writing an accurate description of a field is what exposed that the field's declaration and its runtime behaviour disagreed.

Based on `class-variables`, which supplies the docstrings these declarations belong to.

## Changes

### `src/tmuxp/cli/freeze.py`

**`--quiet`**: help said *"don't prompt for confirmation"*. The flag only guards informational output — every `if not args.quiet` wraps a `tmuxp_echo` call. Confirmation prompts still run; `--yes` is the flag that skips them. A user reaching for `-q` to get an unattended freeze would still be sitting at a prompt.

**`--force`**: help said *"overwrite the workspace file"*. It only relaxes the existence check inside the interactive destination prompt (`if not args.force and os.path.exists(dest_prompt)`). When `-o` is given there is no existence check at all, so `--force` is a no-op on the path most users pair it with.

**`save_to`**: declared `str | None`, but argparse stores a `PosixPath`. Correcting the annotation surfaced three genuine type errors that the wrong declaration had been masking — the destination is funnelled through a local that becomes a `str`. That conversion is now explicit at the boundary.

### `src/tmuxp/cli/load.py`

`CLIColorsLiteral` was `Literal[56, 88]`. `-2` stores `const=256` and `-8` stores `const=88`, so the type admitted a value nothing produces and rejected one of the two the flags actually assign. `56` reads as a dropped digit from `256`.

### `src/tmuxp/cli/shell.py`, `src/tmuxp/cli/__init__.py`

`CLIShellNamespace.colors` and `.log_file` are declared, but the `shell` subparser defines no `-2`/`-8` and no `--log-file`, and `command_shell` reads neither. `CLINamespace.version` is declared, but `--version` uses argparse's version action, which prints and exits with `dest` suppressed. All three are absent from the parsed namespace.

## Verification

Confirm `-2` yields the value the corrected literal admits:

```console
$ python -c "from tmuxp.cli import create_parser; print(create_parser().parse_args(['load','x','-2']).colors)"
```

Confirm the removed annotations never had a value:

```console
$ python -c "from tmuxp.cli import create_parser; n=create_parser().parse_args(['shell']); print(hasattr(n,'colors'), hasattr(n,'log_file'))"
```

## Test plan

- [x] `test_freeze_save_to_parses_as_a_path` — the parsed value is a `pathlib.Path`, matching the declaration
- [x] `test_freeze_quiet_help_describes_what_it_silences` — help names output suppression and points at `--yes`
- [x] `test_freeze_force_help_scopes_itself_to_the_prompt` — help scopes itself to the prompted destination
- [x] `uv run ruff format` / `ruff check` clean
- [x] `uv run mypy src/ tests/` clean, including the three errors the corrected `save_to` type exposed
- [x] Full suite green